### PR TITLE
Gitlab 110 - Ensure tests better asses if desired outcome has been reached

### DIFF
--- a/tests/base/cart.spec.ts
+++ b/tests/base/cart.spec.ts
@@ -21,14 +21,13 @@ test.describe('Cart functionalities (guest)', () => {
    *  @and I should see the product in the minicart
    */
   test.beforeEach(async ({ page }) => {
-    const mainMenu = new MainMenuPage(page);
+    // const mainMenu = new MainMenuPage(page);
     const productPage = new ProductPage(page);
 
     await page.goto(slugs.productpage.simpleProductSlug);
     await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
-    await mainMenu.openMiniCart();
-    await expect(page.getByText(outcomeMarker.miniCart.simpleProductInCartTitle)).toBeVisible();
     await page.goto(slugs.cartSlug);
+    await expect(page.getByRole('strong').getByRole('link', { name: UIReference.productPage.simpleProductTitle }),`${UIReference.productPage.simpleProductTitle} is in the cart`).toBeVisible();
   });
 
   /**

--- a/tests/base/cart.spec.ts
+++ b/tests/base/cart.spec.ts
@@ -31,6 +31,13 @@ test.describe('Cart functionalities (guest)', () => {
     await page.goto(slugs.cartSlug);
   });
 
+  /**
+   * @feature Product can be added to cart
+   * @scenario User adds a product to their cart
+   * @given I have added a product to my cart
+   *  @and I am on the cart page
+   * @then I should see the name of the product in my cart
+   */
   test('Product can be added to cart',{ tag: '@cart',}, async ({page}) => {
     await expect(page.getByRole('strong').getByRole('link', {name: UIReference.productPage.simpleProductTitle}), `Product is visible in cart`).toBeVisible();
   });

--- a/tests/base/cart.spec.ts
+++ b/tests/base/cart.spec.ts
@@ -21,13 +21,9 @@ test.describe('Cart functionalities (guest)', () => {
    *  @and I should see the product in the minicart
    */
   test.beforeEach(async ({ page }) => {
-    // const mainMenu = new MainMenuPage(page);
     const productPage = new ProductPage(page);
-
-    await page.goto(slugs.productpage.simpleProductSlug);
     await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
     await page.goto(slugs.cartSlug);
-    await expect(page.getByRole('strong').getByRole('link', { name: UIReference.productPage.simpleProductTitle }),`${UIReference.productPage.simpleProductTitle} is in the cart`).toBeVisible();
   });
 
   /**

--- a/tests/base/config/element-identifiers/element-identifiers.json
+++ b/tests/base/config/element-identifiers/element-identifiers.json
@@ -5,7 +5,8 @@
     "genericPriceLabel": "Price",
     "genericPriceSymbol": "$",
     "addToCartLabel": "Add to Cart",
-    "closeMessageLabel": "Close message"
+    "closeMessageLabel": "Close message",
+    "removeLabel": "Remove"
   },
   "mainMenu": {
     "myAccountButtonLabel": "My Account",

--- a/tests/base/config/element-identifiers/element-identifiers.json
+++ b/tests/base/config/element-identifiers/element-identifiers.json
@@ -36,6 +36,7 @@
     "addAddressButtonLabel": "ADD NEW ADDRESS",
     "addressDeleteIconButton": "trash",
     "editAddressIconButton": "pencil-alt",
+    "addressBookArea": ".block-addresses-list",
     "links": {
       "newsletterLink": "Newsletter Subscriptions"
     }

--- a/tests/base/fixtures/account.page.ts
+++ b/tests/base/fixtures/account.page.ts
@@ -176,7 +176,7 @@ export class AccountPage {
       await this.deleteAddressButton.click();
       await this.page.waitForLoadState();
 
-      await expect(this.page.getByText(addressDeletedNotification)).toBeVisible();
+      await expect.soft(this.page.getByText(addressDeletedNotification)).toBeVisible();
     }
   }
 }

--- a/tests/base/fixtures/account.page.ts
+++ b/tests/base/fixtures/account.page.ts
@@ -116,6 +116,8 @@ export class AccountPage {
 
   async deleteFirstAddressFromAddressBook(){
     let addressDeletedNotification = outcomeMarker.address.addressDeletedNotification;
+    let addressBookSection = this.page.locator(UIReference.accountDashboard.addressBookArea);
+
     // Dialog function to click confirm
     this.page.on('dialog', async (dialog) => {
       if (dialog.type() === 'confirm') {
@@ -123,9 +125,16 @@ export class AccountPage {
       }
     });
 
+    // Grab addresses from the address book, split the string and grab the address to be deleted.
+    let addressBookArray = await addressBookSection.allInnerTexts();
+    let arraySplit = addressBookArray[0].split('\n');
+    let addressToBeDeleted = arraySplit[7];
+    
     await this.deleteAddressButton.click();
     await this.page.waitForLoadState();
+
     await expect(this.page.getByText(addressDeletedNotification)).toBeVisible();
+    await expect(addressBookSection, `${addressToBeDeleted} should not be visible`).not.toContainText(addressToBeDeleted);
   }
 
   async updatePassword(currentPassword:string, newPassword: string){

--- a/tests/base/fixtures/cart.page.ts
+++ b/tests/base/fixtures/cart.page.ts
@@ -17,6 +17,23 @@ export class CartPage {
     this.showDiscountButton = this.page.getByRole('button', { name: UIReference.cart.showDiscountFormButtonLabel });
   }
 
+  // ==============================================
+  // Product-related methods
+  // ==============================================
+
+  async removeProduct(productTitle: string){
+    let removeButton = this.page.getByLabel(`${UIReference.general.removeLabel} ${productTitle}`);
+    await removeButton.click();
+    await this.page.waitForLoadState();
+    await expect(removeButton,`Button to remove specified product is not visible in the cart`).toBeHidden();
+    
+    // Expect product to no longer be visible in the cart
+    await expect (this.page.getByRole('cell', { name: productTitle }), `Product is not visible in cart`).toBeHidden();
+  }
+
+  // ==============================================
+  // Discount-related methods
+  // ==============================================
   async applyDiscountCode(code: string){
     if(await this.page.getByPlaceholder(UIReference.cart.discountInputFieldLabel).isHidden()){
       // discount field is not open.
@@ -35,23 +52,6 @@ export class CartPage {
     await this.page.getByLabel(UIReference.general.closeMessageLabel).click();
   }
 
-  async enterWrongCouponCode(code: string){
-    if(await this.page.getByPlaceholder(UIReference.cart.discountInputFieldLabel).isHidden()){
-      // discount field is not open.
-      await this.showDiscountButton.click();
-    }
-
-    let applyDiscoundButton = this.page.getByRole('button', {name: UIReference.cart.applyDiscountButtonLabel, exact:true});
-    let discountField = this.page.getByPlaceholder(UIReference.cart.discountInputFieldLabel);
-    await discountField.fill(code);
-    await applyDiscoundButton.click();
-    await this.page.waitForLoadState();
-
-    let incorrectNotification = `${outcomeMarker.cart.incorrectCouponCodeNotificationOne} "${code}" ${outcomeMarker.cart.incorrectCouponCodeNotificationTwo}`;
-
-    await expect(this.page.getByText(incorrectNotification), `Code should not work`).toBeVisible();
-  }
-
   async removeDiscountCode(){
     if(await this.page.getByPlaceholder(UIReference.cart.discountInputFieldLabel).isHidden()){
       // discount field is not open.
@@ -66,13 +66,29 @@ export class CartPage {
     await expect(this.page.getByText(outcomeMarker.cart.priceReducedSymbols),`'- $' should not be on the page`).toBeHidden();
   }
 
-  async removeProduct(name: string){
-    //let removeButton = this.page.getByLabel(`${UIReference.cart.cancelCouponButtonLabel} ${name}`);
-    let removeButton = this.page.getByLabel(`Remove ${name}`);
-    await removeButton.click();
+  async enterWrongCouponCode(code: string){
+    if(await this.page.getByPlaceholder(UIReference.cart.discountInputFieldLabel).isHidden()){
+      // discount field is not open.
+      await this.showDiscountButton.click();
+    }
+
+    let applyDiscoundButton = this.page.getByRole('button', {name: UIReference.cart.applyDiscountButtonLabel, exact:true});
+    let discountField = this.page.getByPlaceholder(UIReference.cart.discountInputFieldLabel);
+    await discountField.fill(code);
+    await applyDiscoundButton.click();
     await this.page.waitForLoadState();
-    await expect(removeButton,`Button to remove product is no longer visible`).toBeHidden();
+
+    let incorrectNotification = `${outcomeMarker.cart.incorrectCouponCodeNotificationOne} "${code}" ${outcomeMarker.cart.incorrectCouponCodeNotificationTwo}`;
+
+    //Assertions: notification that code was incorrect & discount code field is still editable
+    await expect(this.page.getByText(incorrectNotification), `Code should not work`).toBeVisible();
+    await expect(discountField).toBeEditable();
   }
+
+
+  // ==============================================
+  // Additional methods
+  // ==============================================
 
   async getCheckoutValues(productName:string, pricePDP:string, amountPDP:string){
     // Open minicart based on amount of products in cart

--- a/tests/base/fixtures/cart.page.ts
+++ b/tests/base/fixtures/cart.page.ts
@@ -46,7 +46,7 @@ export class CartPage {
     await applyDiscoundButton.click();
     await this.page.waitForLoadState();
     
-    await expect(this.page.getByText(`${outcomeMarker.cart.discountAppliedNotification} "${code}"`),`Notification that discount code ${code} has been applied`).toBeVisible();
+    await expect.soft(this.page.getByText(`${outcomeMarker.cart.discountAppliedNotification} "${code}"`),`Notification that discount code ${code} has been applied`).toBeVisible();
     await expect(this.page.getByText(outcomeMarker.cart.priceReducedSymbols),`'- $' should be visible on the page`).toBeVisible();
     //Close message to prevent difficulties with other tests.
     await this.page.getByLabel(UIReference.general.closeMessageLabel).click();
@@ -62,7 +62,7 @@ export class CartPage {
     await cancelCouponButton.click();
     await this.page.waitForLoadState();
 
-    await expect(this.page.getByText(outcomeMarker.cart.discountRemovedNotification),`Notification should be visible`).toBeVisible();
+    await expect.soft(this.page.getByText(outcomeMarker.cart.discountRemovedNotification),`Notification should be visible`).toBeVisible();
     await expect(this.page.getByText(outcomeMarker.cart.priceReducedSymbols),`'- $' should not be on the page`).toBeHidden();
   }
 
@@ -81,7 +81,7 @@ export class CartPage {
     let incorrectNotification = `${outcomeMarker.cart.incorrectCouponCodeNotificationOne} "${code}" ${outcomeMarker.cart.incorrectCouponCodeNotificationTwo}`;
 
     //Assertions: notification that code was incorrect & discount code field is still editable
-    await expect(this.page.getByText(incorrectNotification), `Code should not work`).toBeVisible();
+    await expect.soft(this.page.getByText(incorrectNotification), `Code should not work`).toBeVisible();
     await expect(discountField).toBeEditable();
   }
 

--- a/tests/base/fixtures/cart.page.ts
+++ b/tests/base/fixtures/cart.page.ts
@@ -54,7 +54,7 @@ export class CartPage {
 
   async removeDiscountCode(){
     if(await this.page.getByPlaceholder(UIReference.cart.discountInputFieldLabel).isHidden()){
-      // discount field is not open.
+      // discount field is not open. 
       await this.showDiscountButton.click();
     }
   

--- a/tests/base/fixtures/checkout.page.ts
+++ b/tests/base/fixtures/checkout.page.ts
@@ -52,7 +52,7 @@ export class CheckoutPage {
       return element && getComputedStyle(element).height === '0px';
     });
 
-    await expect(this.page.getByText(orderPlacedNotification)).toBeVisible();
+    await expect.soft(this.page.getByText(orderPlacedNotification)).toBeVisible();
     let orderNumber = await this.page.locator('p').filter({ hasText: outcomeMarker.checkout.orderPlacedNumberText }).getByRole('link').innerText();
 
     await expect(this.continueShoppingButton, `${outcomeMarker.checkout.orderPlacedNumberText} ${orderNumber}`).toBeVisible();
@@ -82,7 +82,7 @@ export class CheckoutPage {
     await checkoutDiscountField.fill(code);
     await applyCouponCheckoutButton.click();
 
-    await expect(this.page.getByText(`${outcomeMarker.checkout.couponAppliedNotification}`),`Notification that discount code ${code} has been applied`).toBeVisible({timeout: 30000});
+    await expect.soft(this.page.getByText(`${outcomeMarker.checkout.couponAppliedNotification}`),`Notification that discount code ${code} has been applied`).toBeVisible({timeout: 30000});
     await expect(this.page.getByText(outcomeMarker.checkout.checkoutPriceReducedSymbol),`'-$' should be visible on the page`).toBeVisible();
   }
 
@@ -97,7 +97,8 @@ export class CheckoutPage {
     await checkoutDiscountField.fill(code);
     await applyCouponCheckoutButton.click();
 
-    await expect(this.page.getByText(outcomeMarker.checkout.incorrectDiscountNotification), `Code should not work`).toBeVisible();
+    await expect.soft(this.page.getByText(outcomeMarker.checkout.incorrectDiscountNotification), `Code should not work`).toBeVisible();
+    await expect(checkoutDiscountField).toBeEditable();
   }
 
   async removeDiscountCode(){
@@ -109,7 +110,10 @@ export class CheckoutPage {
     let cancelCouponButton = this.page.getByRole('button', {name: UIReference.cart.cancelCouponButtonLabel});
     await cancelCouponButton.click();
 
-    await expect(this.page.getByText(outcomeMarker.checkout.couponRemovedNotification),`Notification should be visible`).toBeVisible();
+    await expect.soft(this.page.getByText(outcomeMarker.checkout.couponRemovedNotification),`Notification should be visible`).toBeVisible();
     await expect(this.page.getByText(outcomeMarker.checkout.checkoutPriceReducedSymbol),`'-$' should not be on the page`).toBeHidden();
+
+    let checkoutDiscountField = this.page.getByPlaceholder(UIReference.checkout.discountInputFieldLabel);
+    await expect(checkoutDiscountField).toBeEditable();
   }
 }

--- a/tests/base/fixtures/checkout.page.ts
+++ b/tests/base/fixtures/checkout.page.ts
@@ -22,6 +22,10 @@ export class CheckoutPage {
     this.continueShoppingButton = this.page.getByRole('link', { name: UIReference.checkout.continueShoppingLabel });
   }
 
+  // ==============================================
+  // Order-related methods
+  // ==============================================
+
   async placeOrder(){
     let orderPlacedNotification = outcomeMarker.checkout.orderPlacedNotification;
     await this.page.goto(slugs.checkoutSlug);
@@ -50,13 +54,15 @@ export class CheckoutPage {
 
     await expect(this.page.getByText(orderPlacedNotification)).toBeVisible();
     let orderNumber = await this.page.locator('p').filter({ hasText: outcomeMarker.checkout.orderPlacedNumberText }).getByRole('link').innerText();
-    // console.log(`Your ordernumer is: ${orderNumber}`);
 
-    // This await only exists to report order number to the HTML reporter.
-    // TODO: replace this with a proper way to write something to the HTML reporter.
     await expect(this.continueShoppingButton, `${outcomeMarker.checkout.orderPlacedNumberText} ${orderNumber}`).toBeVisible();
     return orderNumber;
   }
+
+
+  // ==============================================
+  // Discount-related methods
+  // ==============================================
 
   async applyDiscountCodeCheckout(code: string){
     if(await this.page.getByPlaceholder(UIReference.cart.discountInputFieldLabel).isHidden()){

--- a/tests/base/fixtures/mainmenu.page.ts
+++ b/tests/base/fixtures/mainmenu.page.ts
@@ -33,38 +33,13 @@ export class MainMenuPage {
   }
 
   async openMiniCart() {
+    await this.page.reload();
+    // waitFor is added to ensure the minicart button is visible before clicking, mostly as a fix for Firefox.
     await this.mainMenuMiniCartButton.waitFor();
     await this.mainMenuMiniCartButton.click();
     
-    // if(await this.page.locator('#menu-cart-icon > span').isVisible()){
-    //   console.log("Cart is not empty");
-    //   // there are items in the cart
-    //   let miniCartItemCount = await this.page.locator('#menu-cart-icon > span').innerText();
-      
-    //   if(miniCartItemCount == "1") {
-    //     await this.page.getByLabel(`Toggle minicart, ${miniCartItemCount} item`).click();
-    //     // await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${UIReference.miniCart.miniCartToggleLabelOneItem}`).click();
-    //     await expect(this.page.getByText(outcomeMarker.miniCart.miniCartTitle)).toBeVisible();
-    //     return true;
-    //   } else {
-    //     await this.page.getByLabel(`Toggle minicart, ${miniCartItemCount} items`).click();
-    //     await expect(this.page.getByText(outcomeMarker.miniCart.miniCartTitle)).toBeVisible();
-    //     // await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${miniCartItemCount} ${UIReference.miniCart.miniCartToggleLabelMultiItem}`).click();
-    //     return true;
-    //   }
-    // } else {
-    //   console.log("No products found");
-    //   // there are no items in the cart
-    //   // await this.page.getByLabel(`Toggle minicart,\n Cart is empty`).click();
-    //   //await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${UIReference.miniCart.miniCartToggleLabelEmpty}`).click();
-    //   return false;
-    // }
-  
-   // await this.page.locator('#menu-cart-icon > span').innerText();
-    //if(miniCartItemCount = "0")
-    
-    // await this.mainMenuMiniCartButton.click();
-    
+    let miniCartDrawer = this.page.locator("#cart-drawer-title");
+    await expect(miniCartDrawer.getByText(outcomeMarker.miniCart.miniCartTitle)).toBeVisible();
   }
 
   async logout(){

--- a/tests/base/fixtures/mainmenu.page.ts
+++ b/tests/base/fixtures/mainmenu.page.ts
@@ -60,6 +60,8 @@ export class MainMenuPage {
     await this.mainMenuAccountButton.click();
     await this.mainMenuLogoutItem.click();
 
+    //assertions: notification that user is logged out & logout button no longer visible
     await expect(this.page.getByText(outcomeMarker.logout.logoutConfirmationText, { exact: true })).toBeVisible();
+    await expect(this.mainMenuLogoutItem).toBeHidden();
   }
 }

--- a/tests/base/fixtures/mainmenu.page.ts
+++ b/tests/base/fixtures/mainmenu.page.ts
@@ -33,29 +33,32 @@ export class MainMenuPage {
   }
 
   async openMiniCart() {
-    if(await this.page.locator('#menu-cart-icon > span').isVisible()){
-      console.log("Cart is not empty");
-      // there are items in the cart
-      let miniCartItemCount = await this.page.locator('#menu-cart-icon > span').innerText();
+    await this.mainMenuMiniCartButton.waitFor();
+    await this.mainMenuMiniCartButton.click();
+    
+    // if(await this.page.locator('#menu-cart-icon > span').isVisible()){
+    //   console.log("Cart is not empty");
+    //   // there are items in the cart
+    //   let miniCartItemCount = await this.page.locator('#menu-cart-icon > span').innerText();
       
-      if(miniCartItemCount == "1") {
-        await this.page.getByLabel(`Toggle minicart, ${miniCartItemCount} item`).click();
-        // await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${UIReference.miniCart.miniCartToggleLabelOneItem}`).click();
-        await expect(this.page.getByText(outcomeMarker.miniCart.miniCartTitle)).toBeVisible();
-        return true;
-      } else {
-        await this.page.getByLabel(`Toggle minicart, ${miniCartItemCount} items`).click();
-        await expect(this.page.getByText(outcomeMarker.miniCart.miniCartTitle)).toBeVisible();
-        // await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${miniCartItemCount} ${UIReference.miniCart.miniCartToggleLabelMultiItem}`).click();
-        return true;
-      }
-    } else {
-      console.log("No products found");
-      // there are no items in the cart
-      // await this.page.getByLabel(`Toggle minicart,\n Cart is empty`).click();
-      //await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${UIReference.miniCart.miniCartToggleLabelEmpty}`).click();
-      return false;
-    }
+    //   if(miniCartItemCount == "1") {
+    //     await this.page.getByLabel(`Toggle minicart, ${miniCartItemCount} item`).click();
+    //     // await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${UIReference.miniCart.miniCartToggleLabelOneItem}`).click();
+    //     await expect(this.page.getByText(outcomeMarker.miniCart.miniCartTitle)).toBeVisible();
+    //     return true;
+    //   } else {
+    //     await this.page.getByLabel(`Toggle minicart, ${miniCartItemCount} items`).click();
+    //     await expect(this.page.getByText(outcomeMarker.miniCart.miniCartTitle)).toBeVisible();
+    //     // await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${miniCartItemCount} ${UIReference.miniCart.miniCartToggleLabelMultiItem}`).click();
+    //     return true;
+    //   }
+    // } else {
+    //   console.log("No products found");
+    //   // there are no items in the cart
+    //   // await this.page.getByLabel(`Toggle minicart,\n Cart is empty`).click();
+    //   //await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${UIReference.miniCart.miniCartToggleLabelEmpty}`).click();
+    //   return false;
+    // }
   
    // await this.page.locator('#menu-cart-icon > span').innerText();
     //if(miniCartItemCount = "0")

--- a/tests/base/fixtures/mainmenu.page.ts
+++ b/tests/base/fixtures/mainmenu.page.ts
@@ -33,26 +33,35 @@ export class MainMenuPage {
   }
 
   async openMiniCart() {
-    /*if(await this.page.locator('#menu-cart-icon > span').isVisible()){
+    if(await this.page.locator('#menu-cart-icon > span').isVisible()){
+      console.log("Cart is not empty");
       // there are items in the cart
       let miniCartItemCount = await this.page.locator('#menu-cart-icon > span').innerText();
       
       if(miniCartItemCount == "1") {
-        //await this.page.getByLabel("Toggle minicart, 1 item").click();
-        await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${UIReference.miniCart.miniCartToggleLabelOneItem}`).click();
+        await this.page.getByLabel(`Toggle minicart, ${miniCartItemCount} item`).click();
+        // await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${UIReference.miniCart.miniCartToggleLabelOneItem}`).click();
+        await expect(this.page.getByText(outcomeMarker.miniCart.miniCartTitle)).toBeVisible();
+        return true;
       } else {
-        await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${miniCartItemCount} ${UIReference.miniCart.miniCartToggleLabelMultiItem}`).click();
+        await this.page.getByLabel(`Toggle minicart, ${miniCartItemCount} items`).click();
+        await expect(this.page.getByText(outcomeMarker.miniCart.miniCartTitle)).toBeVisible();
+        // await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${miniCartItemCount} ${UIReference.miniCart.miniCartToggleLabelMultiItem}`).click();
+        return true;
       }
     } else {
+      console.log("No products found");
       // there are no items in the cart
-      await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${UIReference.miniCart.miniCartToggleLabelEmpty}`).click();
+      // await this.page.getByLabel(`Toggle minicart,\n Cart is empty`).click();
+      //await this.page.getByLabel(`${UIReference.miniCart.miniCartToggleLabelPrefix} ${UIReference.miniCart.miniCartToggleLabelEmpty}`).click();
+      return false;
     }
-    */
+  
    // await this.page.locator('#menu-cart-icon > span').innerText();
     //if(miniCartItemCount = "0")
     
-    await this.mainMenuMiniCartButton.click();
-    await expect(this.page.getByText(outcomeMarker.miniCart.miniCartTitle)).toBeVisible();
+    // await this.mainMenuMiniCartButton.click();
+    
   }
 
   async logout(){

--- a/tests/base/fixtures/minicart.page.ts
+++ b/tests/base/fixtures/minicart.page.ts
@@ -11,7 +11,6 @@ export class MiniCartPage {
   readonly editProductButton: Locator;
   readonly productQuantityField: Locator;
   readonly updateItemButton: Locator;
-  readonly removeProductMiniCartButton: Locator;
   readonly cartQuantityField: Locator;
   readonly priceOnPDP: Locator;
   readonly priceInMinicart: Locator;
@@ -23,7 +22,6 @@ export class MiniCartPage {
     this.editProductButton = page.getByLabel(UIReference.miniCart.editProductIconLabel);
     this.productQuantityField = page.getByLabel(UIReference.miniCart.productQuantityFieldLabel);
     this.updateItemButton = page.getByRole('button', { name: UIReference.cart.updateItemButtonLabel });
-    this.removeProductMiniCartButton = page.getByLabel(UIReference.miniCart.removeProductIconLabel).first();
     this.priceOnPDP = page.getByLabel(UIReference.general.genericPriceLabel).getByText(UIReference.general.genericPriceSymbol);
     this.priceInMinicart = page.getByText(UIReference.general.genericPriceSymbol).first();
   }
@@ -38,10 +36,12 @@ export class MiniCartPage {
     await expect(this.page).toHaveURL(new RegExp(`${slugs.cartSlug}.*`));
   }
 
-  async removeProductFromMinicart() {
+  async removeProductFromMinicart(product: string) {
     let productRemovedNotification = outcomeMarker.miniCart.productRemovedConfirmation;
-    await this.removeProductMiniCartButton.click();
+    let removeProductMiniCartButton = this.page.getByLabel(`${UIReference.miniCart.removeProductIconLabel} "${UIReference.productPage.simpleProductTitle}"`);
+    await removeProductMiniCartButton.click();
     await expect(this.page.getByText(productRemovedNotification)).toBeVisible();
+    await expect(removeProductMiniCartButton).toBeHidden();
   }
 
   async updateProduct(amount: string){
@@ -54,7 +54,6 @@ export class MiniCartPage {
     await expect(this.page.getByText(productQuantityChangedNotification)).toBeVisible();
 
     let productQuantityInCart = await this.page.getByLabel(UIReference.cart.cartQuantityLabel).first().inputValue();
-    // console.log(productQuantityInCart);
     expect(productQuantityInCart).toBe(amount);
   }
 

--- a/tests/base/fixtures/minicart.page.ts
+++ b/tests/base/fixtures/minicart.page.ts
@@ -40,7 +40,7 @@ export class MiniCartPage {
     let productRemovedNotification = outcomeMarker.miniCart.productRemovedConfirmation;
     let removeProductMiniCartButton = this.page.getByLabel(`${UIReference.miniCart.removeProductIconLabel} "${UIReference.productPage.simpleProductTitle}"`);
     await removeProductMiniCartButton.click();
-    await expect(this.page.getByText(productRemovedNotification)).toBeVisible();
+    await expect.soft(this.page.getByText(productRemovedNotification)).toBeVisible();
     await expect(removeProductMiniCartButton).toBeHidden();
   }
 
@@ -51,7 +51,7 @@ export class MiniCartPage {
 
     await this.productQuantityField.fill(amount);
     await this.updateItemButton.click();
-    await expect(this.page.getByText(productQuantityChangedNotification)).toBeVisible();
+    await expect.soft(this.page.getByText(productQuantityChangedNotification)).toBeVisible();
 
     let productQuantityInCart = await this.page.getByLabel(UIReference.cart.cartQuantityLabel).first().inputValue();
     expect(productQuantityInCart).toBe(amount);

--- a/tests/base/fixtures/product.page.ts
+++ b/tests/base/fixtures/product.page.ts
@@ -1,5 +1,7 @@
 import {expect, type Locator, type Page} from '@playwright/test';
 
+import slugs from '../config/slugs.json';
+
 import UIReference from '../config/element-identifiers/element-identifiers.json';
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 

--- a/tests/base/fixtures/product.page.ts
+++ b/tests/base/fixtures/product.page.ts
@@ -18,7 +18,6 @@ export class ProductPage {
     this.simpleProductTitle = this.page.getByRole('heading', {name: product, exact:true});
     let productAddedNotification = `${outcomeMarker.productPage.simpleProductAddedNotification} ${product}`;
 
-    await this.page.goto(url);
     this.simpleProductTitle = this.page.getByRole('heading', {name: product, exact:true});
     expect(await this.simpleProductTitle.innerText()).toEqual(product);
     await expect(this.simpleProductTitle.locator('span')).toBeVisible();

--- a/tests/base/fixtures/register.page.ts
+++ b/tests/base/fixtures/register.page.ts
@@ -24,7 +24,8 @@ export class RegisterPage {
   }
 
 
-  async createNewAccount(firstName: string, lastName: string, email: string, password: string){  
+  async createNewAccount(firstName: string, lastName: string, email: string, password: string){
+    let accountInformationField = this.page.locator('.column > div > div > .flex').first();
     await this.page.goto(slugs.account.createAccountSlug);
 
     await this.accountCreationFirstNameField.fill(firstName);
@@ -34,7 +35,11 @@ export class RegisterPage {
     await this.accountCreationPasswordRepeatField.fill(password);
     await this.accountCreationConfirmButton.click();
 
+    // Assertions: Account created notification, navigated to account page, email visible on page
     await expect(this.page.getByText(outcomeMarker.account.accountCreatedNotificationText)).toBeVisible();
+    await expect(this.page).toHaveURL(slugs.account.accountOverviewSlug);
+    await expect(accountInformationField).toContainText(email);
+
     // log credentials to console to add to .env file
     //console.log(`Account created with credentials: email address "${email}" and password "${password}"`);
   }

--- a/tests/base/mainmenu.spec.ts
+++ b/tests/base/mainmenu.spec.ts
@@ -43,16 +43,11 @@ test('Navigate to account page', { tag: '@mainmenu', }, async ({page}) => {
 });
 
 test('Open the minicart', { tag: '@mainmenu', }, async ({page}, testInfo) => {
-  const mainMenu = new MainMenuPage(page);
-  await mainMenu.openMiniCart();
+  testInfo.annotations.push({ type: 'WARNING (FIREFOX)', description: `The minicart icon does not lose its aria-disabled=true flag when the first product is added. This prevents Playwright from clicking it. A fix will be added in the future.`});
 
-  // if(!productInCart){
-  //   // No product in cart: aria-disabled="true" prevents Playwright from clicking the button.
-  //   // Add product, then try again.
-  //   const productPage = new ProductPage(page);
-  //   await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
-  //   //navigate to any page to ensure minicart bubble is visible
-  //   await page.goto('/');
-  //   await mainMenu.openMiniCart();
-  // }
+  const mainMenu = new MainMenuPage(page);
+  const productPage = new ProductPage(page); 
+  
+  await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
+  await mainMenu.openMiniCart();
 });

--- a/tests/base/mainmenu.spec.ts
+++ b/tests/base/mainmenu.spec.ts
@@ -42,17 +42,17 @@ test('Navigate to account page', { tag: '@mainmenu', }, async ({page}) => {
   await mainMenu.gotoMyAccount();
 });
 
-test('Open the minicart', { tag: '@mainmenu', }, async ({page}) => {
+test('Open the minicart', { tag: '@mainmenu', }, async ({page}, testInfo) => {
   const mainMenu = new MainMenuPage(page);
-  let productInCart = await mainMenu.openMiniCart();
+  await mainMenu.openMiniCart();
 
-  if(!productInCart){
-    // No product in cart: aria-disabled="true" prevents Playwright from clicking the button.
-    // Add product, then try again.
-    const productPage = new ProductPage(page);
-    await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
-    //navigate to any page to ensure minicart bubble is visible
-    await page.goto('/');
-    await mainMenu.openMiniCart();
-  }
+  // if(!productInCart){
+  //   // No product in cart: aria-disabled="true" prevents Playwright from clicking the button.
+  //   // Add product, then try again.
+  //   const productPage = new ProductPage(page);
+  //   await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
+  //   //navigate to any page to ensure minicart bubble is visible
+  //   await page.goto('/');
+  //   await mainMenu.openMiniCart();
+  // }
 });

--- a/tests/base/mainmenu.spec.ts
+++ b/tests/base/mainmenu.spec.ts
@@ -1,6 +1,10 @@
 import {test} from '@playwright/test';
 import {LoginPage} from './fixtures/login.page';
 import {MainMenuPage} from './fixtures/mainmenu.page';
+import { ProductPage } from './fixtures/product.page';
+
+import UIReference from './config/element-identifiers/element-identifiers.json';
+import slugs from './config/slugs.json';
 
 // no resetting storageState, mainmenu has more functionalities when logged in.
 
@@ -36,4 +40,19 @@ test('User can log out', { tag: '@mainmenu', }, async ({page}) => {
 test('Navigate to account page', { tag: '@mainmenu', }, async ({page}) => {
   const mainMenu = new MainMenuPage(page);
   await mainMenu.gotoMyAccount();
+});
+
+test('Open the minicart', { tag: '@mainmenu', }, async ({page}) => {
+  const mainMenu = new MainMenuPage(page);
+  let productInCart = await mainMenu.openMiniCart();
+
+  if(!productInCart){
+    // No product in cart: aria-disabled="true" prevents Playwright from clicking the button.
+    // Add product, then try again.
+    const productPage = new ProductPage(page);
+    await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
+    //navigate to any page to ensure minicart bubble is visible
+    await page.goto('/');
+    await mainMenu.openMiniCart();
+  }
 });

--- a/tests/base/minicart.spec.ts
+++ b/tests/base/minicart.spec.ts
@@ -26,7 +26,6 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
 
     await page.goto(slugs.productpage.simpleProductSlug);
     await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
-    await page.reload();
     await mainMenu.openMiniCart();
     await expect(page.getByText(outcomeMarker.miniCart.simpleProductInCartTitle)).toBeVisible();
   });
@@ -81,7 +80,8 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
    *  @then The product should not be in my cart anymore
    *  @and I should see a notification that the product was removed
    */
-  test('Delete product from minicart',{ tag: '@minicart-simple-product',}, async ({page}) => {
+  test('Delete product from minicart',{ tag: '@minicart-simple-product',}, async ({page}, testInfo) => {
+    testInfo.annotations.push({ type: 'WARNING (FIREFOX)', description: `The minicart icon does not lose its aria-disabled=true flag when the first product is added. This prevents Playwright from clicking it. A fix will be added in the future.`});
     const miniCart = new MiniCartPage(page);
     await miniCart.removeProductFromMinicart(UIReference.productPage.simpleProductTitle);
   });

--- a/tests/base/minicart.spec.ts
+++ b/tests/base/minicart.spec.ts
@@ -26,6 +26,7 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
 
     await page.goto(slugs.productpage.simpleProductSlug);
     await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
+    await page.reload();
     await mainMenu.openMiniCart();
     await expect(page.getByText(outcomeMarker.miniCart.simpleProductInCartTitle)).toBeVisible();
   });
@@ -82,7 +83,7 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
    */
   test('Delete product from minicart',{ tag: '@minicart-simple-product',}, async ({page}) => {
     const miniCart = new MiniCartPage(page);
-    await miniCart.removeProductFromMinicart();
+    await miniCart.removeProductFromMinicart(UIReference.productPage.simpleProductTitle);
   });
 
   /**


### PR DESCRIPTION
Changes

- Most tests now have an additional check to ensure the desired outcome has actually been reached (or not!)
- `expects` that asses if a notification is shown are now so called `soft expects`: the test will continue but mark the test. This is to ensure the additional check can still run.
- **Known issue for Firefox**: The minicart button in the menu does not lose the "aria-disabled=true" flag when the first product is added to the cart, even after reload() and waitFor(). This prevents Playwright from opening the minicart and therefore continuing the test. Only consistently happens in UI mode, only when the first product gets added. Sometimes succeeds and sometimes fails when run from the terminal.