### PR TITLE
Gitlab-146: Added test toggle for the setup script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cp playwright.config.example.ts playwright.config.ts
           cp bypass-captcha.config.example.ts bypass-captcha.config.ts
-          cp /tests/base/config/test-toggles.example.json /tests/base/config/test-toggles.json
+          cp tests/base/config/test-toggles.example.json tests/base/config/test-toggles.json
 
       - name: Run Playwright setup test
         run: npx playwright test --reporter=line --workers=4 tests/base/setup.spec.ts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           cp playwright.config.example.ts playwright.config.ts
           cp bypass-captcha.config.example.ts bypass-captcha.config.ts
+          cp /tests/base/config/test-toggles.example.json /tests/base/config/test-toggles.json
 
       - name: Run Playwright setup test
         run: npx playwright test --reporter=line --workers=4 tests/base/setup.spec.ts

--- a/tests/base/config/test-toggles.example.json
+++ b/tests/base/config/test-toggles.example.json
@@ -1,5 +1,6 @@
 {
   "general": {
+    "setup": false,
     "pageHealthCheck": false
   }
 }

--- a/tests/base/config/test-toggles.json
+++ b/tests/base/config/test-toggles.json
@@ -1,5 +1,6 @@
 {
   "general": {
+    "setup": false,
     "pageHealthCheck": false
   }
 }

--- a/tests/base/config/test-toggles.json
+++ b/tests/base/config/test-toggles.json
@@ -1,6 +1,0 @@
-{
-  "general": {
-    "setup": false,
-    "pageHealthCheck": false
-  }
-}

--- a/tests/base/setup.spec.ts
+++ b/tests/base/setup.spec.ts
@@ -14,20 +14,19 @@ import path from 'path';
 
 /**
  * NOTE:
- * This first if-statement checks if the setup variable has been set to true.
- * If so, the testing suite ONLY runs the setup test.
- * Below (starting at line 132), we check if the testing suite is bein run in CI.
- * If so, we run the setup tests. 
+ * The first if-statement checks if we are running in CI.
+ * if so, we always run the setup.
+ * else, we check if the 'setup' test toggle in test-toggles.json has been set to true. 
+ * This is to ensure the tests always run in CI, but otherwise only run when requested.
  */
 
-if(toggles.general.setup) {
+if(process.env.CI) {
   /**
-   * This test is used to set up the testing environment.
-   * It should only be run once, or when the environment needs to be reset.
-   * It is skipped by default, but can be run by setting the 'general.setup' toggle to true.
+   * If we are running in CI, we want to run the setup tests,
+   * But NOT exclusively.
    */
-  base.describe.only('Setting up the testing environment', () => {
-
+  base.describe('Setting up the testing environment', () => {
+  
     base('Enable multiple Magento admin logins', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
       const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
       const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
@@ -127,112 +126,115 @@ if(toggles.general.setup) {
       });
     });
   });
-}
-
-if(process.env.CI) {
-/**
- * If we are running in CI, we want to run the setup tests,
- * But NOT exclusively.
- */
-base.describe('Setting up the testing environment', () => {
-
-  base('Enable multiple Magento admin logins', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
-    const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-    const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
-
-    if (!magentoAdminUsername || !magentoAdminPassword) {
-      throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-    }
-
-    const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-
+} else {
+  if(toggles.general.setup) {
     /**
-     * Only enable multiple admin logins for Chromium browser.
+     * This test is used to set up the testing environment.
+     * It should only be run once, or when the environment needs to be reset.
+     * It is skipped by default, but can be run by setting the 'general.setup' toggle to true.
      */
-    if (browserEngine === "CHROMIUM") {
-      const magentoAdminPage = new MagentoAdminPage(page);
-      await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
-      await magentoAdminPage.enableMultipleAdminLogins();
-    } else {
-      testInfo.skip(true, `Skipping because configuration is only needed once.`);
-    }
-  });
-
-  base('Setup Magento environment for tests', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
-    const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-    const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
-    const isSetupComplete = process.env[setupCompleteVar];
-
-    if(isSetupComplete === 'DONE') {
-      testInfo.skip(true, `Skipping because configuration is only needed once.`);
-    }
-
-    await base.step(`Step 1: Perform actions`, async() =>{
-      const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-      const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
-
-      if (!magentoAdminUsername || !magentoAdminPassword) {
-        throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-      }
-
-      const magentoAdminPage = new MagentoAdminPage(page);
-      await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
-
-      const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-
-      const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
-      if (!couponCode) {
-        throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
-      }
-      await magentoAdminPage.addCartPriceRule(couponCode);
-      await magentoAdminPage.disableLoginCaptcha();
-
-      const registerPage = new RegisterPage(page);
-
-      const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-      const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-      if (!accountEmail || !accountPassword) {
-        throw new Error(
-          `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
-        );
-      }
-
-      await registerPage.createNewAccount(
-        values.accountCreation.firstNameValue,
-        values.accountCreation.lastNameValue,
-        accountEmail,
-        accountPassword,
-        true
-      );
-    });
-
-    await base.step(`Step 2: (optional) Update env file`, async() =>{
-      if (process.env.CI === 'true') {
-        console.log("Running in CI environment. Skipping .env update.");
-        base.skip();
-      }
-
-      const envPath = path.resolve(__dirname, '../../.env');
-      try {
-        if (fs.existsSync(envPath)) {
-          const envContent = fs.readFileSync(envPath, 'utf-8');
-          const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-          if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}='DONE'`)) {
-            fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}='DONE'`);
-            console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}='DONE'' added to .env file.`);
-          }
-          // if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}=true`)) {
-          //   fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}=true`);
-          //   console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}=true' added to .env file.`);
-          // }
-        } else {
-          throw new Error('.env file not found. Please ensure it exists in the root directory.');
+    base.describe.only('Setting up the testing environment', () => {
+  
+      base('Enable multiple Magento admin logins', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
+        const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
+        const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
+    
+        if (!magentoAdminUsername || !magentoAdminPassword) {
+          throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
         }
-      } catch (error) {
-        throw new Error(`Failed to update .env file: ${error.message}`);
-      }
+    
+        const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+    
+        /**
+         * Only enable multiple admin logins for Chromium browser.
+         */
+        if (browserEngine === "CHROMIUM") {
+          const magentoAdminPage = new MagentoAdminPage(page);
+          await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
+          await magentoAdminPage.enableMultipleAdminLogins();
+        } else {
+          testInfo.skip(true, `Skipping because configuration is only needed once.`);
+        }
+      });
+    
+      base('Setup Magento environment for tests', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
+        const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+        const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
+        const isSetupComplete = process.env[setupCompleteVar];
+    
+        if(isSetupComplete === 'DONE') {
+          testInfo.skip(true, `Skipping because configuration is only needed once.`);
+        }
+    
+        await base.step(`Step 1: Perform actions`, async() =>{
+          const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
+          const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
+    
+          if (!magentoAdminUsername || !magentoAdminPassword) {
+            throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
+          }
+    
+          const magentoAdminPage = new MagentoAdminPage(page);
+          await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
+    
+          const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+    
+          const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
+          if (!couponCode) {
+            throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
+          }
+          await magentoAdminPage.addCartPriceRule(couponCode);
+          await magentoAdminPage.disableLoginCaptcha();
+    
+          const registerPage = new RegisterPage(page);
+    
+          const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
+          const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
+    
+          if (!accountEmail || !accountPassword) {
+            throw new Error(
+              `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
+            );
+          }
+    
+          await registerPage.createNewAccount(
+            values.accountCreation.firstNameValue,
+            values.accountCreation.lastNameValue,
+            accountEmail,
+            accountPassword,
+            true
+          );
+        });
+    
+        await base.step(`Step 2: (optional) Update env file`, async() =>{
+          if (process.env.CI === 'true') {
+            console.log("Running in CI environment. Skipping .env update.");
+            base.skip();
+          }
+    
+          const envPath = path.resolve(__dirname, '../../.env');
+          try {
+            if (fs.existsSync(envPath)) {
+              const envContent = fs.readFileSync(envPath, 'utf-8');
+              const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+              if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}='DONE'`)) {
+                fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}='DONE'`);
+                console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}='DONE'' added to .env file.`);
+              }
+              // if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}=true`)) {
+              //   fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}=true`);
+              //   console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}=true' added to .env file.`);
+              // }
+            } else {
+              throw new Error('.env file not found. Please ensure it exists in the root directory.');
+            }
+          } catch (error) {
+            throw new Error(`Failed to update .env file: ${error.message}`);
+          }
+        });
+      });
     });
-  });
-});
+  }
 }
+
+

--- a/tests/base/setup.spec.ts
+++ b/tests/base/setup.spec.ts
@@ -1,110 +1,122 @@
 import { test as base } from '@playwright/test';
 import {faker} from '@faker-js/faker';
+import toggles from './config/test-toggles.json';
 
 import { MagentoAdminPage } from './fixtures/magentoAdmin.page';
 import { RegisterPage } from './fixtures/register.page';
 import { AccountPage } from './fixtures/account.page';
+
 
 import values from './config/input-values/input-values.json';
 
 import fs from 'fs';
 import path from 'path';
 
-base('Enable multiple Magento admin logins', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
-  const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-  const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
-
-  if (!magentoAdminUsername || !magentoAdminPassword) {
-    throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-  }
-
-  const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-
+if(toggles.general.setup === true) {
   /**
-   * Only enable multiple admin logins for Chromium browser.
+   * This test is used to set up the testing environment.
+   * It should only be run once, or when the environment needs to be reset.
+   * It is skipped by default, but can be run by setting the 'general.setup' toggle to true.
    */
-  if (browserEngine === "CHROMIUM") {
-    const magentoAdminPage = new MagentoAdminPage(page);
-    await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
-    await magentoAdminPage.enableMultipleAdminLogins();
-  } else {
-    testInfo.skip(true, `Skipping because configuration is only needed once.`);
-  }
-});
+  base.describe.only('Setting up the testing environment', () => {
 
-base('Setup Magento environment for tests', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
-  const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
-  const isSetupComplete = process.env[setupCompleteVar];
-
-  if(isSetupComplete === 'DONE') {
-    testInfo.skip(true, `Skipping because configuration is only needed once.`);
-  }
-
-  await base.step(`Step 1: Perform actions`, async() =>{
-    const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-    const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
-
-    if (!magentoAdminUsername || !magentoAdminPassword) {
-      throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-    }
-
-    const magentoAdminPage = new MagentoAdminPage(page);
-    await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
-
-    const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-
-    const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
-    if (!couponCode) {
-      throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
-    }
-    await magentoAdminPage.addCartPriceRule(couponCode);
-    await magentoAdminPage.disableLoginCaptcha();
-
-    const registerPage = new RegisterPage(page);
-
-    const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-    const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-    if (!accountEmail || !accountPassword) {
-      throw new Error(
-        `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
-      );
-    }
-
-    await registerPage.createNewAccount(
-      values.accountCreation.firstNameValue,
-      values.accountCreation.lastNameValue,
-      accountEmail,
-      accountPassword,
-      true
-    );
-  });
-
-  await base.step(`Step 2: (optional) Update env file`, async() =>{
-    if (process.env.CI === 'true') {
-      console.log("Running in CI environment. Skipping .env update.");
-      base.skip();
-    }
-
-    const envPath = path.resolve(__dirname, '../../.env');
-    try {
-      if (fs.existsSync(envPath)) {
-        const envContent = fs.readFileSync(envPath, 'utf-8');
-        const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-        if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}='DONE'`)) {
-          fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}='DONE'`);
-          console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}='DONE'' added to .env file.`);
-        }
-        // if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}=true`)) {
-        //   fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}=true`);
-        //   console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}=true' added to .env file.`);
-        // }
-      } else {
-        throw new Error('.env file not found. Please ensure it exists in the root directory.');
+    base('Enable multiple Magento admin logins', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
+      const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
+      const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
+  
+      if (!magentoAdminUsername || !magentoAdminPassword) {
+        throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
       }
-    } catch (error) {
-      throw new Error(`Failed to update .env file: ${error.message}`);
-    }
+  
+      const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+  
+      /**
+       * Only enable multiple admin logins for Chromium browser.
+       */
+      if (browserEngine === "CHROMIUM") {
+        const magentoAdminPage = new MagentoAdminPage(page);
+        await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
+        await magentoAdminPage.enableMultipleAdminLogins();
+      } else {
+        testInfo.skip(true, `Skipping because configuration is only needed once.`);
+      }
+    });
+  
+    base('Setup Magento environment for tests', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
+      const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+      const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
+      const isSetupComplete = process.env[setupCompleteVar];
+  
+      if(isSetupComplete === 'DONE') {
+        testInfo.skip(true, `Skipping because configuration is only needed once.`);
+      }
+  
+      await base.step(`Step 1: Perform actions`, async() =>{
+        const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
+        const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
+  
+        if (!magentoAdminUsername || !magentoAdminPassword) {
+          throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
+        }
+  
+        const magentoAdminPage = new MagentoAdminPage(page);
+        await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
+  
+        const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+  
+        const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
+        if (!couponCode) {
+          throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
+        }
+        await magentoAdminPage.addCartPriceRule(couponCode);
+        await magentoAdminPage.disableLoginCaptcha();
+  
+        const registerPage = new RegisterPage(page);
+  
+        const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
+        const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
+  
+        if (!accountEmail || !accountPassword) {
+          throw new Error(
+            `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
+          );
+        }
+  
+        await registerPage.createNewAccount(
+          values.accountCreation.firstNameValue,
+          values.accountCreation.lastNameValue,
+          accountEmail,
+          accountPassword,
+          true
+        );
+      });
+  
+      await base.step(`Step 2: (optional) Update env file`, async() =>{
+        if (process.env.CI === 'true') {
+          console.log("Running in CI environment. Skipping .env update.");
+          base.skip();
+        }
+  
+        const envPath = path.resolve(__dirname, '../../.env');
+        try {
+          if (fs.existsSync(envPath)) {
+            const envContent = fs.readFileSync(envPath, 'utf-8');
+            const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+            if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}='DONE'`)) {
+              fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}='DONE'`);
+              console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}='DONE'' added to .env file.`);
+            }
+            // if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}=true`)) {
+            //   fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}=true`);
+            //   console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}=true' added to .env file.`);
+            // }
+          } else {
+            throw new Error('.env file not found. Please ensure it exists in the root directory.');
+          }
+        } catch (error) {
+          throw new Error(`Failed to update .env file: ${error.message}`);
+        }
+      });
+    });
   });
-});
+}

--- a/tests/base/setup.spec.ts
+++ b/tests/base/setup.spec.ts
@@ -12,7 +12,15 @@ import values from './config/input-values/input-values.json';
 import fs from 'fs';
 import path from 'path';
 
-if(toggles.general.setup === true) {
+/**
+ * NOTE:
+ * This first if-statement checks if the setup variable has been set to true.
+ * If so, the testing suite ONLY runs the setup test.
+ * Below (starting at line 132), we check if the testing suite is bein run in CI.
+ * If so, we run the setup tests. 
+ */
+
+if(toggles.general.setup) {
   /**
    * This test is used to set up the testing environment.
    * It should only be run once, or when the environment needs to be reset.
@@ -119,4 +127,112 @@ if(toggles.general.setup === true) {
       });
     });
   });
+}
+
+if(process.env.CI) {
+/**
+ * If we are running in CI, we want to run the setup tests,
+ * But NOT exclusively.
+ */
+base.describe('Setting up the testing environment', () => {
+
+  base('Enable multiple Magento admin logins', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
+    const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
+    const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
+
+    if (!magentoAdminUsername || !magentoAdminPassword) {
+      throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
+    }
+
+    const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+
+    /**
+     * Only enable multiple admin logins for Chromium browser.
+     */
+    if (browserEngine === "CHROMIUM") {
+      const magentoAdminPage = new MagentoAdminPage(page);
+      await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
+      await magentoAdminPage.enableMultipleAdminLogins();
+    } else {
+      testInfo.skip(true, `Skipping because configuration is only needed once.`);
+    }
+  });
+
+  base('Setup Magento environment for tests', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
+    const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+    const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
+    const isSetupComplete = process.env[setupCompleteVar];
+
+    if(isSetupComplete === 'DONE') {
+      testInfo.skip(true, `Skipping because configuration is only needed once.`);
+    }
+
+    await base.step(`Step 1: Perform actions`, async() =>{
+      const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
+      const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
+
+      if (!magentoAdminUsername || !magentoAdminPassword) {
+        throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
+      }
+
+      const magentoAdminPage = new MagentoAdminPage(page);
+      await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
+
+      const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+
+      const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
+      if (!couponCode) {
+        throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
+      }
+      await magentoAdminPage.addCartPriceRule(couponCode);
+      await magentoAdminPage.disableLoginCaptcha();
+
+      const registerPage = new RegisterPage(page);
+
+      const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
+      const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
+
+      if (!accountEmail || !accountPassword) {
+        throw new Error(
+          `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
+        );
+      }
+
+      await registerPage.createNewAccount(
+        values.accountCreation.firstNameValue,
+        values.accountCreation.lastNameValue,
+        accountEmail,
+        accountPassword,
+        true
+      );
+    });
+
+    await base.step(`Step 2: (optional) Update env file`, async() =>{
+      if (process.env.CI === 'true') {
+        console.log("Running in CI environment. Skipping .env update.");
+        base.skip();
+      }
+
+      const envPath = path.resolve(__dirname, '../../.env');
+      try {
+        if (fs.existsSync(envPath)) {
+          const envContent = fs.readFileSync(envPath, 'utf-8');
+          const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+          if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}='DONE'`)) {
+            fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}='DONE'`);
+            console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}='DONE'' added to .env file.`);
+          }
+          // if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}=true`)) {
+          //   fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}=true`);
+          //   console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}=true' added to .env file.`);
+          // }
+        } else {
+          throw new Error('.env file not found. Please ensure it exists in the root directory.');
+        }
+      } catch (error) {
+        throw new Error(`Failed to update .env file: ${error.message}`);
+      }
+    });
+  });
+});
 }

--- a/tests/custom/config/test-toggles.example.json
+++ b/tests/custom/config/test-toggles.example.json
@@ -1,5 +1,6 @@
 {
   "general": {
+    "setup": false,
     "pageHealthCheck": false
   }
 }


### PR DESCRIPTION
Added a test toggle that will run only the setup script if set to true, and skips it when set to false. This means you can now run `npx playwright test` without needing to exclude setup.spec.ts