### PR TITLE
Gitlab-169: Setup timeout fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-selftest:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     env:
       BASE_URL: https://hyva-demo.elgentos.io/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - setup-timeout-fix
 
 jobs:
   build-and-selftest:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
           path: playwright-report/
 
       - name: Run Playwright tests
-        run: npx playwright test --workers=4 --grep-invert "@setup" --max-failures=1
+        run: npx playwright test --workers=4 --grep-invert "@setup"
         env:
           CI: true
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-selftest:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     env:
       BASE_URL: https://hyva-demo.elgentos.io/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - setup-timeout-fix
 
 jobs:
   build-and-selftest:
@@ -56,6 +59,11 @@ jobs:
         run: npx playwright test --reporter=line --workers=4 tests/base/setup.spec.ts
         env:
           CI: true
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
 
       - name: Run Playwright tests
         run: npx playwright test --workers=4 --grep-invert "@setup" --max-failures=1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
           cp tests/base/config/test-toggles.example.json tests/base/config/test-toggles.json
 
       - name: Run Playwright setup test
-        run: npx playwright test --reporter=line --workers=4 tests/base/setup.spec.ts
+        run: npx playwright test --reporter=line --workers=4 tests/base/setup.spec.ts --max-failures=1
         env:
           CI: true
       - uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 node_modules/
 /test-results/
 /auth-storage/*
-/playwright-report/*
+/playwright-report/
 /blob-report/
 /playwright/.cache/
 playwright.config.ts

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ node_modules/
 /test-results/
 /auth-storage/*
 /playwright-report/*
-!/playwright-report/.gitkeep
 /blob-report/
 /playwright/.cache/
 playwright.config.ts

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 node_modules/
 /test-results/
 /auth-storage/*
-/playwright-report/
+/playwright-report/*
+!/playwright-report/.gitkeep
 /blob-report/
 /playwright/.cache/
 playwright.config.ts

--- a/tests/base/config/element-identifiers/element-identifiers.json
+++ b/tests/base/config/element-identifiers/element-identifiers.json
@@ -143,6 +143,7 @@
     "homePageTitleText": "Hyvä Themes"
   },
   "magentoAdminPage": {
+    "adminCouponCodeFieldLocator": "#promo_quote_grid_filter_coupon_code",
     "loginButtonLabel": "Sign In",
     "navigation": {
       "marketingButtonLabel": "Marketing",

--- a/tests/base/config/test-toggles.example.json
+++ b/tests/base/config/test-toggles.example.json
@@ -1,6 +1,6 @@
 {
   "general": {
-    "setup": false,
+    "setup": true,
     "pageHealthCheck": false
   }
 }

--- a/tests/base/fixtures/magentoAdmin.page.ts
+++ b/tests/base/fixtures/magentoAdmin.page.ts
@@ -61,8 +61,7 @@ export class MagentoAdminPage {
     await addCartPriceRuleButton.click();
 
     await cartPriceRuleField.waitFor();
-    // await cartPriceRuleField.fill(values.coupon.couponCodeRuleName);
-    await cartPriceRuleField.fill(magentoCouponCode);
+    await cartPriceRuleField.fill(values.coupon.couponCodeRuleName);
 
     // Apply coupon code to all store views
     const websiteSelector = this.page.getByLabel(UIReference.cartPriceRulesPage.websitesSelectLabel);

--- a/tests/base/fixtures/magentoAdmin.page.ts
+++ b/tests/base/fixtures/magentoAdmin.page.ts
@@ -26,20 +26,13 @@ export class MagentoAdminPage {
 
     await this.page.goto(process.env.MAGENTO_ADMIN_SLUG);
     await this.adminLoginButton.waitFor();
-    // await this.page.waitForLoadState('networkidle');
     await this.adminLoginEmailField.fill(username);
     await this.adminLoginPasswordField.fill(password);
     await this.adminLoginButton.click();
-    // await this.page.waitForLoadState('networkidle');
     await storesButton.waitFor();
   }
 
   async addCartPriceRule(magentoCouponCode: string){
-    // if(!process.env.MAGENTO_COUPON_CODE_CHROMIUM || !process.env.MAGENTO_COUPON_CODE_FIREFOX || !process.env.MAGENTO_COUPON_CODE_WEBKIT) {
-    //   throw new Error("MAGENTO_COUPON_CODE_CHROMIUM, MAGENTO_COUPON_CODE_FIREFOX or MAGENTO_COUPON_CODE_WEBKIT is not defined in your .env file.");
-    // }
-
-
     const marketingButton = this.page.getByRole('link', {name: UIReference.magentoAdminPage.navigation.marketingButtonLabel});
     const cartPriceRulesButton = this.page.getByRole('link', {name: UIReference.magentoAdminPage.subNavigation.cartPriceRulesButtonLabel});
     const addCartPriceRuleButton = this.page.getByRole('button', {name: UIReference.cartPriceRulesPage.addCartPriceRuleButtonLabel});
@@ -54,7 +47,7 @@ export class MagentoAdminPage {
     // Before adding the coupon codes, we check if they are already present.
     const searchCouponButton = this.page.getByRole('button', {name: 'Search', exact: true});
 
-    await this.page.locator('#promo_quote_grid_filter_coupon_code').fill(magentoCouponCode);
+    await this.page.locator(UIReference.magentoAdminPage.adminCouponCodeFieldLocator).fill(magentoCouponCode);
     await searchCouponButton.click();
 
     const couponResult = this.page.getByText(magentoCouponCode);
@@ -132,11 +125,6 @@ export class MagentoAdminPage {
     await advancedAdministrationTab.waitFor();
     await advancedAdministrationTab.click();
 
-    // await this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel }).click();
-    // await this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel }).click();
-    // await this.page.getByRole('tab', { name: UIReference.configurationPage.advancedTabLabel }).click();
-    // await this.page.getByRole('link', { name: UIReference.configurationPage.advancedAdministrationTabLabel, exact: true }).click();
-
     if (!await this.page.locator(UIReference.configurationPage.allowMultipleLoginsSystemCheckbox).isVisible()) {
       await this.page.getByRole('link', { name: UIReference.configurationPage.securitySectionLabel }).click();
     }
@@ -165,13 +153,6 @@ export class MagentoAdminPage {
 
     await customerConfigurationTab.waitFor();
     await customerConfigurationTab.click();
-
-    // await this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel }).click();
-    // await this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel }).click();
-    // await this.page.waitForLoadState('networkidle');
-    // await this.page.getByRole('tab', { name: UIReference.configurationPage.customersTabLabel }).click();
-    // await this.page.getByRole('link', { name: UIReference.configurationPage.customerConfigurationTabLabel }).click();
-    // await this.page.waitForLoadState('networkidle');
 
     // Wait for save config button to be visible
     await this.page.getByRole('button', { name: UIReference.configurationPage.saveConfigButtonLabel }).waitFor();    

--- a/tests/base/fixtures/magentoAdmin.page.ts
+++ b/tests/base/fixtures/magentoAdmin.page.ts
@@ -17,31 +17,56 @@ export class MagentoAdminPage {
   }
 
   async login(username: string, password: string){
+    // Define 'Stores' button so we can wait for it's visibility.
+    const storesButton = this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel });
+
     if(!process.env.MAGENTO_ADMIN_SLUG) {
       throw new Error("MAGENTO_ADMIN_SLUG is not defined in your .env file.");
     }
 
     await this.page.goto(process.env.MAGENTO_ADMIN_SLUG);
-    await this.page.waitForLoadState('networkidle');
+    await this.adminLoginButton.waitFor();
+    // await this.page.waitForLoadState('networkidle');
     await this.adminLoginEmailField.fill(username);
     await this.adminLoginPasswordField.fill(password);
     await this.adminLoginButton.click();
-    await this.page.waitForLoadState('networkidle');
+    // await this.page.waitForLoadState('networkidle');
+    await storesButton.waitFor();
   }
 
   async addCartPriceRule(magentoCouponCode: string){
-    if(!process.env.MAGENTO_COUPON_CODE_CHROMIUM || !process.env.MAGENTO_COUPON_CODE_FIREFOX || !process.env.MAGENTO_COUPON_CODE_WEBKIT) {
-      throw new Error("MAGENTO_COUPON_CODE_CHROMIUM, MAGENTO_COUPON_CODE_FIREFOX or MAGENTO_COUPON_CODE_WEBKIT is not defined in your .env file.");
-    }
+    // if(!process.env.MAGENTO_COUPON_CODE_CHROMIUM || !process.env.MAGENTO_COUPON_CODE_FIREFOX || !process.env.MAGENTO_COUPON_CODE_WEBKIT) {
+    //   throw new Error("MAGENTO_COUPON_CODE_CHROMIUM, MAGENTO_COUPON_CODE_FIREFOX or MAGENTO_COUPON_CODE_WEBKIT is not defined in your .env file.");
+    // }
 
-    await this.page.getByRole('link', {name: UIReference.magentoAdminPage.navigation.marketingButtonLabel}).click();
-    await this.page.waitForLoadState('networkidle');
-    //await this.page.getByRole('link', {name: UIReference.magentoAdminPage.subNavigation.cartPriceRulesButtonLabel}).waitFor();
-    await expect(this.page.getByRole('link', {name: UIReference.magentoAdminPage.subNavigation.cartPriceRulesButtonLabel})).toBeVisible();
-    await this.page.getByRole('link', {name: UIReference.magentoAdminPage.subNavigation.cartPriceRulesButtonLabel}).click();
-    await this.page.waitForLoadState('networkidle');
-    await this.page.getByRole('button', {name: UIReference.cartPriceRulesPage.addCartPriceRuleButtonLabel}).click();
-    await this.page.getByLabel(UIReference.cartPriceRulesPage.ruleNameFieldLabel).fill(values.coupon.couponCodeRuleName);
+    const marketingButton = this.page.getByRole('link', {name: UIReference.magentoAdminPage.navigation.marketingButtonLabel});
+    const cartPriceRulesButton = this.page.getByRole('link', {name: UIReference.magentoAdminPage.subNavigation.cartPriceRulesButtonLabel});
+    const addCartPriceRuleButton = this.page.getByRole('button', {name: UIReference.cartPriceRulesPage.addCartPriceRuleButtonLabel});
+    const cartPriceRuleField = this.page.getByLabel(UIReference.cartPriceRulesPage.ruleNameFieldLabel);
+
+    await marketingButton.waitFor();
+    await marketingButton.click();
+
+    await cartPriceRulesButton.waitFor();
+    await cartPriceRulesButton.click();
+
+    await addCartPriceRuleButton.waitFor();
+    await addCartPriceRuleButton.click();
+
+    await cartPriceRuleField.waitFor();
+    await cartPriceRuleField.fill(values.coupon.couponCodeRuleName);
+
+    // await this.page.getByRole('link', {name: UIReference.magentoAdminPage.navigation.marketingButtonLabel}).click();
+    // await this.page.waitForLoadState('networkidle');
+    // //await this.page.getByRole('link', {name: UIReference.magentoAdminPage.subNavigation.cartPriceRulesButtonLabel}).waitFor();
+    // await expect(this.page.getByRole('link', {name: UIReference.magentoAdminPage.subNavigation.cartPriceRulesButtonLabel})).toBeVisible();
+    // await this.page.getByRole('link', {name: UIReference.magentoAdminPage.subNavigation.cartPriceRulesButtonLabel}).click();
+    // await this.page.waitForLoadState('networkidle');
+    // const addCartPriceRuleButton = this.page.getByRole('button', {name: UIReference.cartPriceRulesPage.addCartPriceRuleButtonLabel});
+    // await addCartPriceRuleButton.waitFor();
+    // await addCartPriceRuleButton.click();
+    // // await this.page.getByRole('button', {name: UIReference.cartPriceRulesPage.addCartPriceRuleButtonLabel}).click();
+    // await this.page.getByLabel(UIReference.cartPriceRulesPage.ruleNameFieldLabel).fill(values.coupon.couponCodeRuleName);
 
     const websiteSelector = this.page.getByLabel(UIReference.cartPriceRulesPage.websitesSelectLabel);
     await websiteSelector.evaluate(select => {
@@ -63,17 +88,45 @@ export class MagentoAdminPage {
     await this.page.getByLabel(UIReference.cartPriceRulesPage.couponCodeFieldLabel).fill(magentoCouponCode);
 
     await this.page.getByText(UIReference.cartPriceRulesPage.actionsSubtitleLabel, { exact: true }).click();
-    await this.page.getByLabel(UIReference.cartPriceRulesPage.discountAmountFieldLabel).fill('10');
+    const discountAmountField = this.page.getByLabel(UIReference.cartPriceRulesPage.discountAmountFieldLabel);
+    await discountAmountField.waitFor();
+    await discountAmountField.fill('10');
+    // await this.page.getByLabel(UIReference.cartPriceRulesPage.discountAmountFieldLabel).fill('10');
 
     await this.page.getByRole('button', { name: 'Save', exact: true }).click();
+
+    // Wait for success message to be visible before moving on.
+    const succesMessageLocator = this.page.locator(UIReference.general.successMessageLocator);
+    await succesMessageLocator.waitFor();
   }
 
   async enableMultipleAdminLogins() {
-    await this.page.waitForLoadState('networkidle');
-    await this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel }).click();
-    await this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel }).click();
-    await this.page.getByRole('tab', { name: UIReference.configurationPage.advancedTabLabel }).click();
-    await this.page.getByRole('link', { name: UIReference.configurationPage.advancedAdministrationTabLabel, exact: true }).click();
+    // await this.page.waitForLoadState('networkidle');
+    const storesButton = this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel });
+    const configurationButton = this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel });
+    const advancedTab = this.page.getByRole('tab', { name: UIReference.configurationPage.advancedTabLabel });
+    const advancedAdministrationTab = this.page.getByRole('link', { name: UIReference.configurationPage.advancedAdministrationTabLabel, exact: true });
+
+    // this function is called after login, meaning we should wait for the stores button to be visible
+    await storesButton.waitFor();
+    await storesButton.click();
+
+    // wait for Configuration button to be visible
+    await configurationButton.waitFor();
+    await configurationButton.click();
+
+    // wait for Advanced tab to be visible
+    await advancedTab.waitFor();
+    await advancedTab.click();
+
+    // wait for Advanced Administration tab to be visible
+    await advancedAdministrationTab.waitFor();
+    await advancedAdministrationTab.click();
+
+    // await this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel }).click();
+    // await this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel }).click();
+    // await this.page.getByRole('tab', { name: UIReference.configurationPage.advancedTabLabel }).click();
+    // await this.page.getByRole('link', { name: UIReference.configurationPage.advancedAdministrationTabLabel, exact: true }).click();
 
     if (!await this.page.locator(UIReference.configurationPage.allowMultipleLoginsSystemCheckbox).isVisible()) {
       await this.page.getByRole('link', { name: UIReference.configurationPage.securitySectionLabel }).click();
@@ -85,13 +138,34 @@ export class MagentoAdminPage {
   }
 
   async disableLoginCaptcha() {
-    await this.page.waitForLoadState('networkidle');
-    await this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel }).click();
-    await this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel }).click();
-    await this.page.waitForLoadState('networkidle');
-    await this.page.getByRole('tab', { name: UIReference.configurationPage.customersTabLabel }).click();
-    await this.page.getByRole('link', { name: UIReference.configurationPage.customerConfigurationTabLabel }).click();
-    await this.page.waitForLoadState('networkidle');
+    // No longer required because we wait for success message in the previous method/step.
+    // await this.page.waitForLoadState('networkidle');
+    const storesButton = this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel });
+    const configurationButton = this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel });
+    const customersTab = this.page.getByRole('tab', { name: UIReference.configurationPage.customersTabLabel });
+    const customerConfigurationTab = this.page.getByRole('link', { name: UIReference.configurationPage.customerConfigurationTabLabel });
+
+    await storesButton.waitFor();
+    await storesButton.click();
+
+    await configurationButton.waitFor();
+    await configurationButton.click();
+
+    await customersTab.waitFor();
+    await customersTab.click();
+
+    await customerConfigurationTab.waitFor();
+    await customerConfigurationTab.click();
+
+    // await this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel }).click();
+    // await this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel }).click();
+    // await this.page.waitForLoadState('networkidle');
+    // await this.page.getByRole('tab', { name: UIReference.configurationPage.customersTabLabel }).click();
+    // await this.page.getByRole('link', { name: UIReference.configurationPage.customerConfigurationTabLabel }).click();
+    // await this.page.waitForLoadState('networkidle');
+
+    // Wait for save config button to be visible
+    await this.page.getByRole('button', { name: UIReference.configurationPage.saveConfigButtonLabel }).waitFor();    
 
     if (!await this.page.locator(UIReference.configurationPage.captchaSettingSystemCheckbox).isVisible()) {
       // await this.page.getByRole('link', { name: new RegExp(UIReference.configurationPage.captchaSectionLabel) }).click();
@@ -101,6 +175,9 @@ export class MagentoAdminPage {
     await this.page.locator(UIReference.configurationPage.captchaSettingSystemCheckbox).uncheck();
     await this.page.locator(UIReference.configurationPage.captchaSettingSelectField).selectOption({ label: values.captcha.captchaDisabled });
     await this.page.getByRole('button', { name: UIReference.configurationPage.saveConfigButtonLabel }).click();
-    await this.page.waitForLoadState('networkidle');
+    // await this.page.waitForLoadState('networkidle');
+        // Wait for success message to be visible before moving on.
+        const succesMessageLocator = this.page.locator(UIReference.general.successMessageLocator);
+        await succesMessageLocator.waitFor();
   }
 }

--- a/tests/base/fixtures/register.page.ts
+++ b/tests/base/fixtures/register.page.ts
@@ -28,6 +28,8 @@ export class RegisterPage {
     let accountInformationField = this.page.locator(UIReference.accountDashboard.accountInformationFieldLocator).first();
     await this.page.goto(slugs.account.createAccountSlug);
 
+    await this.accountCreationConfirmButton.waitFor();
+
     await this.accountCreationFirstNameField.fill(firstName);
     await this.accountCreationLastNameField.fill(lastName);
     await this.accountCreationEmailField.fill(email);

--- a/tests/base/setup.spec.ts
+++ b/tests/base/setup.spec.ts
@@ -26,16 +26,25 @@ if(process.env.CI) {
    * But NOT exclusively.
    */
   base.describe('Setting up the testing environment', () => {
-  
+    base.beforeEach('Check if setup is needed', async ({ browserName }, testInfo) => {
+      const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+      const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
+      const isSetupComplete = process.env[setupCompleteVar];
+
+      if(isSetupComplete === 'DONE') {
+        testInfo.skip(true, `Skipping because configuration is only needed once.`);
+      }
+    });
+
     base('Enable multiple Magento admin logins', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
+      
       const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
       const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
+      const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
   
       if (!magentoAdminUsername || !magentoAdminPassword) {
         throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-      }
-  
-      const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+      }    
   
       /**
        * Only enable multiple admin logins for Chromium browser.
@@ -45,50 +54,58 @@ if(process.env.CI) {
         await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
         await magentoAdminPage.enableMultipleAdminLogins();
       } else {
-        testInfo.skip(true, `Skipping because configuration is only needed once.`);
+        testInfo.skip(true, `Skipping, configuration is only needed once. This step will only run in Chromium.`);
       }
     });
   
     base('Setup Magento environment for tests', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
+      // const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+      // const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
+      // const isSetupComplete = process.env[setupCompleteVar];
+  
+      // if(isSetupComplete === 'DONE') {
+      //   testInfo.skip(true, `Skipping because configuration is only needed once.`);
+      // }
+
+      const magentoAdminPage = new MagentoAdminPage(page);
       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-      const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
-      const isSetupComplete = process.env[setupCompleteVar];
   
-      if(isSetupComplete === 'DONE') {
-        testInfo.skip(true, `Skipping because configuration is only needed once.`);
-      }
-  
-      await base.step(`Step 1: Perform actions`, async() =>{
+      await base.step('Step 1: login to admin', async () =>{
         const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
         const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
   
         if (!magentoAdminUsername || !magentoAdminPassword) {
           throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
         }
-  
-        const magentoAdminPage = new MagentoAdminPage(page);
+
+        // const magentoAdminPage = new MagentoAdminPage(page);
         await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
-  
-        const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  
+      });
+
+      await base.step('Step 2: Add cart price rules (coupon codes)', async () =>{
+        // const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
         const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
         if (!couponCode) {
           throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
         }
         await magentoAdminPage.addCartPriceRule(couponCode);
+      });
+
+      await base.step('Step 3: Disable login captcha', async () =>{
         await magentoAdminPage.disableLoginCaptcha();
-  
+      });
+
+      await base.step('Step 4: Create new account', async () =>{
         const registerPage = new RegisterPage(page);
-  
         const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
         const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-  
+
         if (!accountEmail || !accountPassword) {
           throw new Error(
             `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
           );
         }
-  
+
         await registerPage.createNewAccount(
           values.accountCreation.firstNameValue,
           values.accountCreation.lastNameValue,
@@ -96,7 +113,48 @@ if(process.env.CI) {
           accountPassword,
           true
         );
+
       });
+
+      // await base.step(`Step 1: Perform actions`, async() =>{
+      //   const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
+      //   const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
+  
+      //   if (!magentoAdminUsername || !magentoAdminPassword) {
+      //     throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
+      //   }
+  
+      //   const magentoAdminPage = new MagentoAdminPage(page);
+      //   await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
+  
+      //   const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+  
+      //   const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
+      //   if (!couponCode) {
+      //     throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
+      //   }
+      //   await magentoAdminPage.addCartPriceRule(couponCode);
+      //   await magentoAdminPage.disableLoginCaptcha();
+  
+      //   const registerPage = new RegisterPage(page);
+  
+      //   const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
+      //   const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
+  
+      //   if (!accountEmail || !accountPassword) {
+      //     throw new Error(
+      //       `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
+      //     );
+      //   }
+  
+      //   await registerPage.createNewAccount(
+      //     values.accountCreation.firstNameValue,
+      //     values.accountCreation.lastNameValue,
+      //     accountEmail,
+      //     accountPassword,
+      //     true
+      //   );
+      // });
   
       await base.step(`Step 2: (optional) Update env file`, async() =>{
         if (process.env.CI === 'true') {
@@ -126,6 +184,107 @@ if(process.env.CI) {
       });
     });
   });
+  // base.describe('Setting up the testing environment', () => {
+  
+  //   base('Enable multiple Magento admin logins', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
+  //     const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
+  //     const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
+  
+  //     if (!magentoAdminUsername || !magentoAdminPassword) {
+  //       throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
+  //     }
+  
+  //     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+  
+  //     /**
+  //      * Only enable multiple admin logins for Chromium browser.
+  //      */
+  //     if (browserEngine === "CHROMIUM") {
+  //       const magentoAdminPage = new MagentoAdminPage(page);
+  //       await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
+  //       await magentoAdminPage.enableMultipleAdminLogins();
+  //     } else {
+  //       testInfo.skip(true, `Skipping because configuration is only needed once.`);
+  //     }
+  //   });
+  
+  //   base('Setup Magento environment for tests', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
+  //     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+  //     const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
+  //     const isSetupComplete = process.env[setupCompleteVar];
+  
+  //     if(isSetupComplete === 'DONE') {
+  //       testInfo.skip(true, `Skipping because configuration is only needed once.`);
+  //     }
+  
+  //     await base.step(`Step 1: Perform actions`, async() =>{
+  //       const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
+  //       const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
+  
+  //       if (!magentoAdminUsername || !magentoAdminPassword) {
+  //         throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
+  //       }
+  
+  //       const magentoAdminPage = new MagentoAdminPage(page);
+  //       await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
+  
+  //       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+  
+  //       const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
+  //       if (!couponCode) {
+  //         throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
+  //       }
+  //       await magentoAdminPage.addCartPriceRule(couponCode);
+  //       await magentoAdminPage.disableLoginCaptcha();
+  
+  //       const registerPage = new RegisterPage(page);
+  
+  //       const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
+  //       const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
+  
+  //       if (!accountEmail || !accountPassword) {
+  //         throw new Error(
+  //           `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
+  //         );
+  //       }
+  
+  //       await registerPage.createNewAccount(
+  //         values.accountCreation.firstNameValue,
+  //         values.accountCreation.lastNameValue,
+  //         accountEmail,
+  //         accountPassword,
+  //         true
+  //       );
+  //     });
+  
+  //     await base.step(`Step 2: (optional) Update env file`, async() =>{
+  //       if (process.env.CI === 'true') {
+  //         console.log("Running in CI environment. Skipping .env update.");
+  //         base.skip();
+  //       }
+  
+  //       const envPath = path.resolve(__dirname, '../../.env');
+  //       try {
+  //         if (fs.existsSync(envPath)) {
+  //           const envContent = fs.readFileSync(envPath, 'utf-8');
+  //           const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
+  //           if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}='DONE'`)) {
+  //             fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}='DONE'`);
+  //             console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}='DONE'' added to .env file.`);
+  //           }
+  //           // if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}=true`)) {
+  //           //   fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}=true`);
+  //           //   console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}=true' added to .env file.`);
+  //           // }
+  //         } else {
+  //           throw new Error('.env file not found. Please ensure it exists in the root directory.');
+  //         }
+  //       } catch (error) {
+  //         throw new Error(`Failed to update .env file: ${error.message}`);
+  //       }
+  //     });
+  //   });
+  // });
 } else {
   if(toggles.general.setup) {
     /**

--- a/tests/base/setup.spec.ts
+++ b/tests/base/setup.spec.ts
@@ -88,7 +88,14 @@ if(process.env.CI) {
         if (!couponCode) {
           throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
         }
-        await magentoAdminPage.addCartPriceRule(couponCode);
+        const addCouponCode = await magentoAdminPage.addCartPriceRule(couponCode);
+        
+        if(!addCouponCode) {
+          // Coupon Code has likely already been added
+          testInfo.annotations.push({type: 'Warning', 
+            description: `The coupon code "${couponCode}" has already been found. If you think this isn't correct, please check before continuing.`});
+          console.log(`The coupon code "${couponCode}" has already been found. If you think this isn't correct, please check before continuing.`);
+        }
       });
 
       await base.step('Step 3: Disable login captcha', async () =>{
@@ -115,48 +122,8 @@ if(process.env.CI) {
         );
 
       });
-
-      // await base.step(`Step 1: Perform actions`, async() =>{
-      //   const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-      //   const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
   
-      //   if (!magentoAdminUsername || !magentoAdminPassword) {
-      //     throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-      //   }
-  
-      //   const magentoAdminPage = new MagentoAdminPage(page);
-      //   await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
-  
-      //   const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  
-      //   const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
-      //   if (!couponCode) {
-      //     throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
-      //   }
-      //   await magentoAdminPage.addCartPriceRule(couponCode);
-      //   await magentoAdminPage.disableLoginCaptcha();
-  
-      //   const registerPage = new RegisterPage(page);
-  
-      //   const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-      //   const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-  
-      //   if (!accountEmail || !accountPassword) {
-      //     throw new Error(
-      //       `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
-      //     );
-      //   }
-  
-      //   await registerPage.createNewAccount(
-      //     values.accountCreation.firstNameValue,
-      //     values.accountCreation.lastNameValue,
-      //     accountEmail,
-      //     accountPassword,
-      //     true
-      //   );
-      // });
-  
-      await base.step(`Step 2: (optional) Update env file`, async() =>{
+      await base.step(`Step 5: (optional) Update env file`, async() =>{
         if (process.env.CI === 'true') {
           console.log("Running in CI environment. Skipping .env update.");
           base.skip();
@@ -184,107 +151,6 @@ if(process.env.CI) {
       });
     });
   });
-  // base.describe('Setting up the testing environment', () => {
-  
-  //   base('Enable multiple Magento admin logins', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
-  //     const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-  //     const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
-  
-  //     if (!magentoAdminUsername || !magentoAdminPassword) {
-  //       throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-  //     }
-  
-  //     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  
-  //     /**
-  //      * Only enable multiple admin logins for Chromium browser.
-  //      */
-  //     if (browserEngine === "CHROMIUM") {
-  //       const magentoAdminPage = new MagentoAdminPage(page);
-  //       await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
-  //       await magentoAdminPage.enableMultipleAdminLogins();
-  //     } else {
-  //       testInfo.skip(true, `Skipping because configuration is only needed once.`);
-  //     }
-  //   });
-  
-  //   base('Setup Magento environment for tests', {tag: '@setup',}, async ({ page, browserName }, testInfo) => {
-  //     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  //     const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
-  //     const isSetupComplete = process.env[setupCompleteVar];
-  
-  //     if(isSetupComplete === 'DONE') {
-  //       testInfo.skip(true, `Skipping because configuration is only needed once.`);
-  //     }
-  
-  //     await base.step(`Step 1: Perform actions`, async() =>{
-  //       const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-  //       const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
-  
-  //       if (!magentoAdminUsername || !magentoAdminPassword) {
-  //         throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-  //       }
-  
-  //       const magentoAdminPage = new MagentoAdminPage(page);
-  //       await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
-  
-  //       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  
-  //       const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
-  //       if (!couponCode) {
-  //         throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
-  //       }
-  //       await magentoAdminPage.addCartPriceRule(couponCode);
-  //       await magentoAdminPage.disableLoginCaptcha();
-  
-  //       const registerPage = new RegisterPage(page);
-  
-  //       const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-  //       const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-  
-  //       if (!accountEmail || !accountPassword) {
-  //         throw new Error(
-  //           `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
-  //         );
-  //       }
-  
-  //       await registerPage.createNewAccount(
-  //         values.accountCreation.firstNameValue,
-  //         values.accountCreation.lastNameValue,
-  //         accountEmail,
-  //         accountPassword,
-  //         true
-  //       );
-  //     });
-  
-  //     await base.step(`Step 2: (optional) Update env file`, async() =>{
-  //       if (process.env.CI === 'true') {
-  //         console.log("Running in CI environment. Skipping .env update.");
-  //         base.skip();
-  //       }
-  
-  //       const envPath = path.resolve(__dirname, '../../.env');
-  //       try {
-  //         if (fs.existsSync(envPath)) {
-  //           const envContent = fs.readFileSync(envPath, 'utf-8');
-  //           const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  //           if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}='DONE'`)) {
-  //             fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}='DONE'`);
-  //             console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}='DONE'' added to .env file.`);
-  //           }
-  //           // if (!envContent.includes(`SETUP_COMPLETE_${browserEngine}=true`)) {
-  //           //   fs.appendFileSync(envPath, `\nSETUP_COMPLETE_${browserEngine}=true`);
-  //           //   console.log(`Environment setup completed successfully. 'SETUP_COMPLETE_${browserEngine}=true' added to .env file.`);
-  //           // }
-  //         } else {
-  //           throw new Error('.env file not found. Please ensure it exists in the root directory.');
-  //         }
-  //       } catch (error) {
-  //         throw new Error(`Failed to update .env file: ${error.message}`);
-  //       }
-  //     });
-  //   });
-  // });
 } else {
   if(toggles.general.setup) {
     /**
@@ -355,7 +221,14 @@ if(process.env.CI) {
           if (!couponCode) {
             throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
           }
-          await magentoAdminPage.addCartPriceRule(couponCode);
+          const addCouponCode = await magentoAdminPage.addCartPriceRule(couponCode);
+          
+          if(!addCouponCode) {
+            // Coupon Code has likely already been added
+            testInfo.annotations.push({type: 'Warning', 
+              description: `The coupon code "${couponCode}" has already been found. If you think this isn't correct, please check before continuing.`});
+            console.log(`The coupon code "${couponCode}" has already been found. If you think this isn't correct, please check before continuing.`);
+          }
         });
 
         await base.step('Step 3: Disable login captcha', async () =>{
@@ -382,48 +255,8 @@ if(process.env.CI) {
           );
 
         });
-
-        // await base.step(`Step 1: Perform actions`, async() =>{
-        //   const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-        //   const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
     
-        //   if (!magentoAdminUsername || !magentoAdminPassword) {
-        //     throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-        //   }
-    
-        //   const magentoAdminPage = new MagentoAdminPage(page);
-        //   await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
-    
-        //   const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-    
-        //   const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
-        //   if (!couponCode) {
-        //     throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
-        //   }
-        //   await magentoAdminPage.addCartPriceRule(couponCode);
-        //   await magentoAdminPage.disableLoginCaptcha();
-    
-        //   const registerPage = new RegisterPage(page);
-    
-        //   const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-        //   const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-    
-        //   if (!accountEmail || !accountPassword) {
-        //     throw new Error(
-        //       `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
-        //     );
-        //   }
-    
-        //   await registerPage.createNewAccount(
-        //     values.accountCreation.firstNameValue,
-        //     values.accountCreation.lastNameValue,
-        //     accountEmail,
-        //     accountPassword,
-        //     true
-        //   );
-        // });
-    
-        await base.step(`Step 2: (optional) Update env file`, async() =>{
+        await base.step(`Step 5: (optional) Update env file`, async() =>{
           if (process.env.CI === 'true') {
             console.log("Running in CI environment. Skipping .env update.");
             base.skip();


### PR DESCRIPTION
This commit mostly reworks `setup.spec.ts` and `magentoAdmin.page.ts`. An overview of the most important changes:

- The test `setting up Magento environment` test(group) in `setup.spec.ts` has now been broken down in clearer steps to show the user what is being done, making it easier to scan and fix errors when necessary.
- The step `add Coupon Codes` now checks if the codes from `.env` can already be found in the admin environment. If so, a notice will be pushed to the console *as well as* the report to notify the user. This ensures the setup will not fail if the coupon codes already exist.
- Removed instances of `waitForLoadState("networkidle")` since this is not according to best practices. Instead, we now use the appropriate `waitFor()`. 
- Updated a small point in the `evaluate()` code where we select all stores when creating the coupon codes to explicitly note the element as `HTMLSelectElement` to ensure we don't get errors in our editors.