### PR TITLE
Fix Magento Admin configuration link

### DIFF
--- a/tests/base/fixtures/magentoAdmin.page.ts
+++ b/tests/base/fixtures/magentoAdmin.page.ts
@@ -71,7 +71,7 @@ export class MagentoAdminPage {
   async enableMultipleAdminLogins() {
     await this.page.waitForLoadState('networkidle');
     await this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel }).click();
-    await this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel }).click();
+    await this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel }).first().click();
     await this.page.getByRole('tab', { name: UIReference.configurationPage.advancedTabLabel }).click();
     await this.page.getByRole('link', { name: UIReference.configurationPage.advancedAdministrationTabLabel, exact: true }).click();
 
@@ -87,7 +87,7 @@ export class MagentoAdminPage {
   async disableLoginCaptcha() {
     await this.page.waitForLoadState('networkidle');
     await this.page.getByRole('link', { name: UIReference.magentoAdminPage.navigation.storesButtonLabel }).click();
-    await this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel }).click();
+    await this.page.getByRole('link', { name: UIReference.magentoAdminPage.subNavigation.configurationButtonLabel }).first().click();
     await this.page.waitForLoadState('networkidle');
     await this.page.getByRole('tab', { name: UIReference.configurationPage.customersTabLabel }).click();
     await this.page.getByRole('link', { name: UIReference.configurationPage.customerConfigurationTabLabel }).click();


### PR DESCRIPTION
## Summary
- handle duplicate "Configuration" links in admin

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68480354445c832b80627a5141bb09ea