### PR TITLE
Add default exports to page objects

### DIFF
--- a/tests/base/account.spec.ts
+++ b/tests/base/account.spec.ts
@@ -1,9 +1,9 @@
 import {test, expect} from '@playwright/test';
-import {MainMenuPage} from './fixtures/mainmenu.page';
-import {LoginPage} from './fixtures/login.page';
-import {RegisterPage} from './fixtures/register.page';
-import {AccountPage} from './fixtures/account.page';
-import {NewsletterSubscriptionPage} from './fixtures/newsletter.page';
+import MainMenuPage from './fixtures/mainmenu.page';
+import LoginPage from './fixtures/login.page';
+import RegisterPage from './fixtures/register.page';
+import AccountPage from './fixtures/account.page';
+import NewsletterSubscriptionPage from './fixtures/newsletter.page';
 import {faker} from '@faker-js/faker';
 
 import slugs from './config/slugs.json';

--- a/tests/base/cart.spec.ts
+++ b/tests/base/cart.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { ProductPage } from './fixtures/product.page';
-import { MainMenuPage } from './fixtures/mainmenu.page';
-import {LoginPage} from './fixtures/login.page';
-import { CartPage } from './fixtures/cart.page';
+import ProductPage from './fixtures/product.page';
+import MainMenuPage from './fixtures/mainmenu.page';
+import LoginPage from './fixtures/login.page';
+import CartPage from './fixtures/cart.page';
 
 import slugs from './config/slugs.json';
 import UIReference from './config/element-identifiers/element-identifiers.json';

--- a/tests/base/checkout.spec.ts
+++ b/tests/base/checkout.spec.ts
@@ -1,8 +1,8 @@
 import {test, expect} from '@playwright/test';
-import {LoginPage} from './fixtures/login.page';
-import {ProductPage} from './fixtures/product.page';
-import {AccountPage} from './fixtures/account.page';
-import { CheckoutPage } from './fixtures/checkout.page';
+import LoginPage from './fixtures/login.page';
+import ProductPage from './fixtures/product.page';
+import AccountPage from './fixtures/account.page';
+import CheckoutPage from './fixtures/checkout.page';
 
 import slugs from './config/slugs.json';
 import UIReference from './config/element-identifiers/element-identifiers.json';

--- a/tests/base/compare.spec.ts
+++ b/tests/base/compare.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
-import {ProductPage} from './fixtures/product.page';
+import ProductPage from './fixtures/product.page';
 import ComparePage from './fixtures/compare.page';
-import {LoginPage} from './fixtures/login.page';
+import LoginPage from './fixtures/login.page';
 
 import slugs from './config/slugs.json';
 import UIReference from './config/element-identifiers/element-identifiers.json';

--- a/tests/base/contact.spec.ts
+++ b/tests/base/contact.spec.ts
@@ -1,5 +1,5 @@
 import {test} from '@playwright/test';
-import { ContactPage } from './fixtures/contact.page';
+import ContactPage from './fixtures/contact.page';
 
 /**
  * @feature Magento 2 Contact Form

--- a/tests/base/fixtures/account.page.ts
+++ b/tests/base/fixtures/account.page.ts
@@ -5,7 +5,7 @@ import UIReference from '../config/element-identifiers/element-identifiers.json'
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 import slugs from '../config/slugs.json';
 
-export class AccountPage {
+class AccountPage {
   readonly page: Page;
   readonly accountDashboardTitle: Locator;
   readonly firstNameField: Locator;
@@ -168,3 +168,5 @@ export class AccountPage {
     }
   }
 }
+
+export default AccountPage;

--- a/tests/base/fixtures/base.page.ts
+++ b/tests/base/fixtures/base.page.ts
@@ -1,6 +1,6 @@
 import { Page } from '@playwright/test';
 
-export class BasePage {
+class BasePage {
   readonly page: Page;
 
   constructor(page: Page) {
@@ -41,3 +41,5 @@ export class BasePage {
     await this.page.waitForTimeout(500);
   }
 }
+
+export default BasePage;

--- a/tests/base/fixtures/cart.page.ts
+++ b/tests/base/fixtures/cart.page.ts
@@ -3,7 +3,7 @@ import {expect, type Locator, type Page} from '@playwright/test';
 import UIReference from '../config/element-identifiers/element-identifiers.json';
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 
-export class CartPage {
+class CartPage {
   readonly page: Page;
   readonly showDiscountButton: Locator;
   readonly applyDiscountButton: Locator;
@@ -146,3 +146,5 @@ export class CartPage {
     expect(calculatedPricePDP, `Price * qty on PDP (${calculatedPricePDP}) equals price * qty in checkout (${priceCheckout})`).toEqual(priceCheckout);
   }
 }
+
+export default CartPage;

--- a/tests/base/fixtures/category.page.ts
+++ b/tests/base/fixtures/category.page.ts
@@ -4,7 +4,7 @@ import UIReference from '../config/element-identifiers/element-identifiers.json'
 
 import slugs from '../config/slugs.json';
 
-export default class CategoryPage {
+class CategoryPage {
   readonly page:Page;
   categoryPageTitle: Locator;
 
@@ -97,3 +97,4 @@ export default class CategoryPage {
     expect(this.page.url(),`URL should contain ?product_list_mode=${newActiveView?.toLowerCase()}`).toContain(`?product_list_mode=${newActiveView?.toLowerCase()}`);
   }
 }
+export default CategoryPage;

--- a/tests/base/fixtures/checkout.page.ts
+++ b/tests/base/fixtures/checkout.page.ts
@@ -1,13 +1,13 @@
 import {expect, type Locator, type Page} from '@playwright/test';
 import {faker} from '@faker-js/faker';
-import { BasePage } from './base.page';
+import BasePage from './base.page';
 
 import UIReference from '../config/element-identifiers/element-identifiers.json';
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 import slugs from '../config/slugs.json';
 import inputvalues from '../config/input-values/input-values.json';
 
-export class CheckoutPage extends BasePage {
+class CheckoutPage extends BasePage {
 
   readonly shippingMethodOptionFixed: Locator;
   readonly paymentMethodOptionCheck: Locator;
@@ -207,3 +207,5 @@ export class CheckoutPage extends BasePage {
     await this.waitForMagewireRequests();
   }
 }
+
+export default CheckoutPage;

--- a/tests/base/fixtures/compare.page.ts
+++ b/tests/base/fixtures/compare.page.ts
@@ -5,7 +5,7 @@ import slugs from '../config/slugs.json';
 import UIReference from '../config/element-identifiers/element-identifiers.json';
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 
-export default class ComparePage {
+class ComparePage {
   page: Page;
 
   constructor(page: Page) {
@@ -44,3 +44,4 @@ export default class ComparePage {
     await successMessage.waitFor();
   }
 }
+export default ComparePage;

--- a/tests/base/fixtures/contact.page.ts
+++ b/tests/base/fixtures/contact.page.ts
@@ -5,7 +5,7 @@ import UIReference from '../config/element-identifiers/element-identifiers.json'
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 import slugs from '../config/slugs.json';
 
-export class ContactPage {
+class ContactPage {
   readonly page: Page;
   readonly nameField: Locator;
   readonly emailField: Locator;
@@ -39,3 +39,5 @@ export class ContactPage {
     await expect(this.messageField, 'message should be empty now').toBeEmpty();
   }
 }
+
+export default ContactPage;

--- a/tests/base/fixtures/home.page.ts
+++ b/tests/base/fixtures/home.page.ts
@@ -2,7 +2,7 @@ import {type Locator, type Page} from '@playwright/test';
 
 import UIReference from '../config/element-identifiers/element-identifiers.json';
 
-export class HomePage {
+class HomePage {
 
   readonly page: Page;
   buyProductButton: Locator;
@@ -21,3 +21,5 @@ export class HomePage {
     }
   }
 }
+
+export default HomePage;

--- a/tests/base/fixtures/login.page.ts
+++ b/tests/base/fixtures/login.page.ts
@@ -3,7 +3,7 @@ import {expect, type Locator, type Page} from '@playwright/test';
 import slugs from '../config/slugs.json';
 import UIReference from '../config/element-identifiers/element-identifiers.json';
 
-export class LoginPage {
+class LoginPage {
   readonly page: Page;
   readonly loginEmailField: Locator;
   readonly loginPasswordField: Locator;
@@ -24,3 +24,5 @@ export class LoginPage {
     await this.loginButton.press("Enter");
   }
 }
+
+export default LoginPage;

--- a/tests/base/fixtures/magentoAdmin.page.ts
+++ b/tests/base/fixtures/magentoAdmin.page.ts
@@ -3,7 +3,7 @@ import {expect, type Locator, type Page} from '@playwright/test';
 import UIReference from '../config/element-identifiers/element-identifiers.json';
 import values from '../config/input-values/input-values.json';
 
-export class MagentoAdminPage {
+class MagentoAdminPage {
   readonly page: Page;
   readonly adminLoginEmailField: Locator;
   readonly adminLoginPasswordField: Locator;
@@ -104,3 +104,5 @@ export class MagentoAdminPage {
     await this.page.waitForLoadState('networkidle');
   }
 }
+
+export default MagentoAdminPage;

--- a/tests/base/fixtures/mainmenu.page.ts
+++ b/tests/base/fixtures/mainmenu.page.ts
@@ -5,7 +5,7 @@ import UIReference from '../config/element-identifiers/element-identifiers.json'
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 
 
-export class MainMenuPage {
+class MainMenuPage {
   readonly page: Page;
   readonly mainMenuAccountButton: Locator;
   readonly mainMenuMiniCartButton: Locator;
@@ -52,3 +52,5 @@ export class MainMenuPage {
     await expect(this.mainMenuLogoutItem).toBeHidden();
   }
 }
+
+export default MainMenuPage;

--- a/tests/base/fixtures/minicart.page.ts
+++ b/tests/base/fixtures/minicart.page.ts
@@ -4,7 +4,7 @@ import UIReference from '../config/element-identifiers/element-identifiers.json'
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 import slugs from '../config/slugs.json';
 
-export class MiniCartPage {
+class MiniCartPage {
   readonly page: Page;
   readonly toCheckoutButton: Locator;
   readonly toCartButton: Locator;
@@ -66,3 +66,5 @@ export class MiniCartPage {
     expect(priceOnPage, `Expect these prices to be the same: priceOnpage: ${priceOnPage} and priceInMinicart: ${priceInMinicart}`).toBe(priceInMinicart);
   }
 }
+
+export default MiniCartPage;

--- a/tests/base/fixtures/newsletter.page.ts
+++ b/tests/base/fixtures/newsletter.page.ts
@@ -2,7 +2,7 @@ import {expect, type Locator, type Page} from '@playwright/test';
 import UIReference from '../config/element-identifiers/element-identifiers.json';
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 
-export class NewsletterSubscriptionPage {
+class NewsletterSubscriptionPage {
   readonly page: Page;
   readonly newsletterCheckElement: Locator;
   readonly saveSubscriptionsButton: Locator;
@@ -38,3 +38,5 @@ export class NewsletterSubscriptionPage {
     return subscribed;
   }
 }
+
+export default NewsletterSubscriptionPage;

--- a/tests/base/fixtures/product.page.ts
+++ b/tests/base/fixtures/product.page.ts
@@ -5,7 +5,7 @@ import slugs from '../config/slugs.json';
 import UIReference from '../config/element-identifiers/element-identifiers.json';
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 
-export class ProductPage {
+class ProductPage {
   readonly page: Page;
   simpleProductTitle: Locator;
   configurableProductTitle: Locator;
@@ -166,3 +166,5 @@ export class ProductPage {
     await expect(this.page.getByText(productAddedNotification)).toBeVisible();
   }
 }
+
+export default ProductPage;

--- a/tests/base/fixtures/register.page.ts
+++ b/tests/base/fixtures/register.page.ts
@@ -4,7 +4,7 @@ import slugs from '../config/slugs.json';
 import UIReference from '../config/element-identifiers/element-identifiers.json';
 import outcomeMarker from '../config/outcome-markers/outcome-markers.json';
 
-export class RegisterPage {
+class RegisterPage {
   readonly page: Page;
   readonly accountCreationFirstNameField: Locator;
   readonly accountCreationLastNameField: Locator;
@@ -43,3 +43,5 @@ export class RegisterPage {
     }
   }
 }
+
+export default RegisterPage;

--- a/tests/base/home.spec.ts
+++ b/tests/base/home.spec.ts
@@ -1,6 +1,6 @@
 import {test, expect} from '@playwright/test';
-import {MainMenuPage} from './fixtures/mainmenu.page';
-import {HomePage} from './fixtures/home.page';
+import MainMenuPage from './fixtures/mainmenu.page';
+import HomePage from './fixtures/home.page';
 
 import outcomeMarker from './config/outcome-markers/outcome-markers.json';
 

--- a/tests/base/login.spec.ts
+++ b/tests/base/login.spec.ts
@@ -1,6 +1,6 @@
 import {test as base, expect} from '@playwright/test';
-import {LoginPage} from './fixtures/login.page';
-import {MainMenuPage} from './fixtures/mainmenu.page';
+import LoginPage from './fixtures/login.page';
+import MainMenuPage from './fixtures/mainmenu.page';
 import inputvalues from './config/input-values/input-values.json';
 
 base('User can log in with valid credentials', async ({page, browserName}) => {

--- a/tests/base/mainmenu.spec.ts
+++ b/tests/base/mainmenu.spec.ts
@@ -1,7 +1,7 @@
 import {test} from '@playwright/test';
-import {LoginPage} from './fixtures/login.page';
-import {MainMenuPage} from './fixtures/mainmenu.page';
-import { ProductPage } from './fixtures/product.page';
+import LoginPage from './fixtures/login.page';
+import MainMenuPage from './fixtures/mainmenu.page';
+import ProductPage from './fixtures/product.page';
 
 import UIReference from './config/element-identifiers/element-identifiers.json';
 import slugs from './config/slugs.json';

--- a/tests/base/minicart.spec.ts
+++ b/tests/base/minicart.spec.ts
@@ -1,7 +1,7 @@
 import {test, expect} from '@playwright/test';
-import {MainMenuPage} from './fixtures/mainmenu.page';
-import {ProductPage} from './fixtures/product.page';
-import { MiniCartPage } from './fixtures/minicart.page';
+import MainMenuPage from './fixtures/mainmenu.page';
+import ProductPage from './fixtures/product.page';
+import MiniCartPage from './fixtures/minicart.page';
 
 import slugs from './config/slugs.json';
 import UIReference from './config/element-identifiers/element-identifiers.json';

--- a/tests/base/product.spec.ts
+++ b/tests/base/product.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
-import {ProductPage} from './fixtures/product.page';
-import {LoginPage} from './fixtures/login.page';
+import ProductPage from './fixtures/product.page';
+import LoginPage from './fixtures/login.page';
 
 import slugs from './config/slugs.json';
 import UIReference from './config/element-identifiers/element-identifiers.json';

--- a/tests/base/register.spec.ts
+++ b/tests/base/register.spec.ts
@@ -1,5 +1,5 @@
 import {test} from '@playwright/test';
-import {RegisterPage} from './fixtures/register.page';
+import RegisterPage from './fixtures/register.page';
 import {faker} from '@faker-js/faker';
 
 import inputvalues from './config/input-values/input-values.json';

--- a/tests/base/setup.spec.ts
+++ b/tests/base/setup.spec.ts
@@ -2,9 +2,9 @@ import { test as base } from '@playwright/test';
 import {faker} from '@faker-js/faker';
 import toggles from './config/test-toggles.json';
 
-import { MagentoAdminPage } from './fixtures/magentoAdmin.page';
-import { RegisterPage } from './fixtures/register.page';
-import { AccountPage } from './fixtures/account.page';
+import MagentoAdminPage from './fixtures/magentoAdmin.page';
+import RegisterPage from './fixtures/register.page';
+import AccountPage from './fixtures/account.page';
 
 
 import values from './config/input-values/input-values.json';


### PR DESCRIPTION
## Summary
- convert POM classes to use default exports
- update imports in specs
- adjust internal POM imports

## Testing
- `npx playwright test --grep-invert @setup` *(fails: Cannot find module './config/test-toggles.json')*

------
https://chatgpt.com/codex/tasks/task_e_6848023e84b0832b886f11092b22b69b