### PR TITLE
Add negative login tests

### DIFF
--- a/tests/base/config/outcome-markers/outcome-markers.json
+++ b/tests/base/config/outcome-markers/outcome-markers.json
@@ -53,6 +53,10 @@
     "borderClassRegex": ".* border-primary$",
     "simpleProductAddedNotification": "You added"
   },
+  "login": {
+    "invalidCredentialsMessage": "The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later.",
+    "requiredFieldMessage": "This is a required field."
+  },
   "wishListPage": {
     "wishListAddedNotification": "has been added to your Wish List."
   }

--- a/tests/base/fixtures/login.page.ts
+++ b/tests/base/fixtures/login.page.ts
@@ -23,4 +23,16 @@ export class LoginPage {
     // usage of .press("Enter") to prevent webkit issues with button.click();
     await this.loginButton.press("Enter");
   }
+
+  async loginExpectError(email: string, password: string, errorMessage: string) {
+    await this.page.goto(slugs.account.loginSlug);
+    await this.loginEmailField.fill(email);
+    await this.loginPasswordField.fill(password);
+    await this.loginButton.press('Enter');
+    await this.page.waitForLoadState('networkidle');
+
+    const message = this.page.locator('#messages');
+    await expect.soft(message, 'Error message should be visible').toContainText(errorMessage);
+    await expect(this.page, 'Should stay on login page').toHaveURL(slugs.account.loginSlug);
+  }
 }

--- a/tests/base/login.spec.ts
+++ b/tests/base/login.spec.ts
@@ -2,6 +2,7 @@ import {test as base, expect} from '@playwright/test';
 import {LoginPage} from './fixtures/login.page';
 import {MainMenuPage} from './fixtures/mainmenu.page';
 import inputvalues from './config/input-values/input-values.json';
+import outcomeMarker from './config/outcome-markers/outcome-markers.json';
 
 base('User can log in with valid credentials', async ({page, browserName}) => {
   const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
@@ -34,4 +35,14 @@ base('User can log in with valid credentials', async ({page, browserName}) => {
 
   expect(parsedData.customer.firstname, 'Customer firstname should match').toBe(inputvalues.accountCreation.firstNameValue);
   expect(parsedData.customer.fullname, 'Customer lastname should match').toContain(inputvalues.accountCreation.lastNameValue);
+});
+
+base('User cannot log in with invalid credentials', async ({page}) => {
+  const loginPage = new LoginPage(page);
+  await loginPage.loginExpectError('invalid@example.com', 'wrongpassword', outcomeMarker.login.invalidCredentialsMessage);
+});
+
+base('Login fails with missing password', async ({page}) => {
+  const loginPage = new LoginPage(page);
+  await loginPage.loginExpectError('invalid@example.com', '', outcomeMarker.login.requiredFieldMessage);
 });


### PR DESCRIPTION
## Summary
- extend login fixture to validate login failure
- store login error messages in outcome markers
- add tests for invalid credentials and missing password

## Testing
- `npm install`
- `npx playwright install chromium`
- `npx playwright test tests/base/login.spec.ts` *(fails: MAGENTO_EXISTING_ACCOUNT_EMAIL not set)*

------
https://chatgpt.com/codex/tasks/task_e_684802f8cb28832ba053c066d3dbcb67