### PR TITLE
HOTFIX: Firefox minicart button (workaround)

### DIFF
--- a/tests/base/fixtures/mainmenu.page.ts
+++ b/tests/base/fixtures/mainmenu.page.ts
@@ -33,9 +33,16 @@ export class MainMenuPage {
   }
 
   async openMiniCart() {
-    await this.page.reload();
+    // await this.page.reload();
+    // FIREFOX_WORKAROUND: wait for 3 seconds to allow minicart to be updated.
+    await this.page.waitForTimeout(3000);
+    const cartAmountBubble = this.mainMenuMiniCartButton.locator('span');
+    cartAmountBubble.waitFor();
+    const amountInCart = await cartAmountBubble.innerText();
+    console.log(amountInCart);
     // waitFor is added to ensure the minicart button is visible before clicking, mostly as a fix for Firefox.
-    await this.mainMenuMiniCartButton.waitFor();
+    // await this.mainMenuMiniCartButton.waitFor();
+
     await this.mainMenuMiniCartButton.click();
 
     let miniCartDrawer = this.page.locator("#cart-drawer-title");

--- a/tests/base/fixtures/mainmenu.page.ts
+++ b/tests/base/fixtures/mainmenu.page.ts
@@ -39,7 +39,7 @@ export class MainMenuPage {
     const cartAmountBubble = this.mainMenuMiniCartButton.locator('span');
     cartAmountBubble.waitFor();
     const amountInCart = await cartAmountBubble.innerText();
-    console.log(amountInCart);
+
     // waitFor is added to ensure the minicart button is visible before clicking, mostly as a fix for Firefox.
     // await this.mainMenuMiniCartButton.waitFor();
 


### PR DESCRIPTION
Note: this is a workaround so the testing suite does not unnecessarily fail. A proper solution will be implemented in the future.

- Implemented a timeout as workaround
- Added a waitFor() to ensure 'amountbubble' is visible
