### PR TITLE
Add search tests

### DIFF
--- a/tests/config/element-identifiers.json
+++ b/tests/config/element-identifiers.json
@@ -187,6 +187,11 @@
     "removeProductIconLabel": "Remove product",
     "toCartLinkLabel": "View and Edit Cart"
   },
+  "search": {
+    "searchToggleLocator": "#menu-search-icon",
+    "searchInputLocator": "#search",
+    "suggestionBoxLocator": "#search_autocomplete"
+  },
   "personalInformation": {
     "changePasswordCheckLabel": "Change Password",
     "firstNameLabel": "First Name",

--- a/tests/config/input-values.json
+++ b/tests/config/input-values.json
@@ -53,5 +53,10 @@
     "secondProvinceValue": "South Dakota",
     "secondStreetAddressValue": "Under the Stairs, 4 Privet Drive",
     "secondZipCodeValue": "67890"
+  },
+  "search": {
+    "queryMultipleResults": "bag",
+    "querySpecificProduct": "Push It Messenger Bag",
+    "queryNoResults": "sdfasdfasddd"
   }
 }

--- a/tests/config/outcome-markers.json
+++ b/tests/config/outcome-markers.json
@@ -56,6 +56,9 @@
   "login": {
     "invalidCredentialsMessage": "The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later."
   },
+  "search": {
+    "noResultsMessage": "Your search returned no results."
+  },
   "wishListPage": {
     "wishListAddedNotification": "has been added to your Wish List."
   }

--- a/tests/config/slugs.json
+++ b/tests/config/slugs.json
@@ -27,6 +27,9 @@
     "secondSimpleProductSlug": "/aim-analog-watch.html",
     "simpleProductSlug": "/push-it-messenger-bag.html"
   },
+  "search": {
+    "resultsSlug": "/catalogsearch/result/"
+  },
   "wishlist": {
     "wishListRegex": ".*wishlist.*"
   }

--- a/tests/poms/frontend/search.page.ts
+++ b/tests/poms/frontend/search.page.ts
@@ -1,0 +1,37 @@
+// @ts-check
+
+import { expect, type Locator, type Page } from '@playwright/test';
+import { UIReference } from 'config';
+
+class SearchPage {
+  readonly page: Page;
+  readonly searchToggle: Locator;
+  readonly searchInput: Locator;
+  readonly suggestionBox: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.searchToggle = page.locator(UIReference.search.searchToggleLocator);
+    this.searchInput = page.locator(UIReference.search.searchInputLocator);
+    this.suggestionBox = page.locator(UIReference.search.suggestionBoxLocator);
+  }
+
+  async openSearch() {
+    await this.searchToggle.click();
+    await expect(this.searchInput).toBeVisible();
+  }
+
+  async search(query: string) {
+    await this.openSearch();
+    await this.searchInput.fill(query);
+    await this.searchInput.press('Enter');
+    await this.page.waitForLoadState('networkidle');
+  }
+
+  async typeQuery(query: string) {
+    await this.openSearch();
+    await this.searchInput.fill(query);
+  }
+}
+
+export default SearchPage;

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -1,0 +1,35 @@
+// @ts-check
+
+import { test, expect } from '@playwright/test';
+import { UIReference, outcomeMarker, inputValues, slugs } from 'config';
+
+import SearchPage from './poms/frontend/search.page';
+
+test.describe('Search functionality', () => {
+  test('Search query returns multiple results', async ({ page }) => {
+    const searchPage = new SearchPage(page);
+    await searchPage.search(inputValues.search.queryMultipleResults);
+    await expect(page).toHaveURL(new RegExp(slugs.search.resultsSlug));
+    const results = page.locator(`${UIReference.categoryPage.productGridLocator} li`);
+    await expect(results).toHaveCountGreaterThan(1);
+  });
+
+  test('User can find a specific product and navigate to its page', async ({ page }) => {
+    const searchPage = new SearchPage(page);
+    await searchPage.search(inputValues.search.querySpecificProduct);
+    await page.getByRole('link', { name: UIReference.productPage.simpleProductTitle }).first().click();
+    await expect(page).toHaveURL(slugs.productpage.simpleProductSlug);
+  });
+
+  test('No results message is shown for unknown query', async ({ page }) => {
+    const searchPage = new SearchPage(page);
+    await searchPage.search(inputValues.search.queryNoResults);
+    await expect(page.getByText(outcomeMarker.search.noResultsMessage)).toBeVisible();
+  });
+
+  test('Suggestions appear while typing', async ({ page }) => {
+    const searchPage = new SearchPage(page);
+    await searchPage.typeQuery(inputValues.search.queryMultipleResults);
+    await expect(searchPage.suggestionBox).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add search strings to config
- reference config in search page object and tests

## Testing
- `npx playwright test --workers=4 --grep-invert "@setup" --max-failures=1` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_685aae71fad8832ba35adc4e31f059d3