### PR TITLE
Fix wrong default baseDir

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 class Build {
 
-  pathToBaseDir = '../../../'
+  pathToBaseDir = './'
   tempDirTests = 'base-tests';
   exampleFileName = '.example';
 


### PR DESCRIPTION
When running this as default settings, an NPM error occurs as `Error: EACCES: permission denied`. If someone runs this with too much NPM permissions, it can overwrite wrong .env files.