### PR TITLE
Fix search result count assertion

### DIFF
--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -12,7 +12,8 @@ test.describe('Search functionality', () => {
     await searchPage.search(inputValues.search.queryMultipleResults);
     await expect(page).toHaveURL(new RegExp(slugs.search.resultsSlug));
     const results = page.locator(`${UIReference.categoryPage.productGridLocator} li`);
-    await expect(results).toHaveCountGreaterThan(1);
+    const resultCount = await results.count();
+    expect(resultCount).toBeGreaterThan(1);
   });
 
   test('User can find a specific product and navigate to its page', async ({ page }) => {


### PR DESCRIPTION
## Summary
- correct search result count assertion to use Playwright matchers

## Testing
- `npx playwright test --workers=4 --grep-invert "@setup" --max-failures=1` *(fails: npm install prompts for input)*

------
https://chatgpt.com/codex/tasks/task_e_685ac7a50488832b8ac4a00de15cce7b