### PR TITLE
Centralize env checks in util

### DIFF
--- a/tests/account.spec.ts
+++ b/tests/account.spec.ts
@@ -9,16 +9,13 @@ import LoginPage from './poms/frontend/login.page';
 import MainMenuPage from './poms/frontend/mainmenu.page';
 import NewsletterSubscriptionPage from './poms/frontend/newsletter.page';
 import RegisterPage from './poms/frontend/register.page';
+import { requireEnv } from './utils/env.utils';
 
 // Before each test, log in
 test.beforeEach(async ({ page, browserName }) => {
   const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-  let passwordInputValue = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-  if(!emailInputValue || !passwordInputValue) {
-    throw new Error("MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} and/or MAGENTO_EXISTING_ACCOUNT_PASSWORD have not defined in the .env file, or the account hasn't been created yet.");
-  }
+  const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
+  const passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
 
   const loginPage = new LoginPage(page);
   await loginPage.login(emailInputValue, passwordInputValue);
@@ -54,8 +51,8 @@ test.describe('Account information actions', {annotation: {type: 'Account Dashbo
     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
     let randomNumberforEmail = Math.floor(Math.random() * 101);
     let emailPasswordUpdatevalue = `passwordupdate-${randomNumberforEmail}-${browserEngine}@example.com`;
-    let passwordInputValue = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-    let changedPasswordValue = process.env.MAGENTO_EXISTING_ACCOUNT_CHANGED_PASSWORD;
+    let passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
+    let changedPasswordValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_CHANGED_PASSWORD');
 
     // Log out of current account
     if(await page.getByRole('link', { name: UIReference.mainMenu.myAccountLogoutItem }).isVisible()){
@@ -63,9 +60,6 @@ test.describe('Account information actions', {annotation: {type: 'Account Dashbo
     }
 
     // Create account
-    if(!changedPasswordValue || !passwordInputValue) {
-      throw new Error("Changed password or original password in your .env file is not defined or could not be read.");
-    }
 
     await registerPage.createNewAccount(faker.person.firstName(), faker.person.lastName(), emailPasswordUpdatevalue, passwordInputValue);
 
@@ -79,10 +73,7 @@ test.describe('Account information actions', {annotation: {type: 'Account Dashbo
 
     // Logout again, login with original account
     await mainMenu.logout();
-    let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-    if(!emailInputValue) {
-      throw new Error("MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} and/or MAGENTO_EXISTING_ACCOUNT_PASSWORD have not defined in the .env file, or the account hasn't been created yet.");
-    }
+    const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
     await loginPage.login(emailInputValue, passwordInputValue);
   });
 });

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -3,17 +3,14 @@
 import { test as setup, expect } from '@playwright/test';
 import path from 'path';
 import { UIReference, slugs } from 'config';
+import { requireEnv } from './utils/env.utils';
 
 const authFile = path.join(__dirname, '../playwright/.auth/user.json');
 
 setup('authenticate', async ({ page, browserName }) => {
   const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-  let passwordInputValue = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-  if(!emailInputValue || !passwordInputValue) {
-    throw new Error("MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} and/or MAGENTO_EXISTING_ACCOUNT_PASSWORD have not defined in the .env file, or the account hasn't been created yet.");
-  }
+  const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
+  const passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
 
   // Perform authentication steps. Replace these actions with your own.
   await page.goto(slugs.account.loginSlug);

--- a/tests/cart.spec.ts
+++ b/tests/cart.spec.ts
@@ -6,6 +6,7 @@ import { UIReference, slugs } from 'config';
 import CartPage from './poms/frontend/cart.page';
 import LoginPage from './poms/frontend/login.page';
 import ProductPage from './poms/frontend/product.page';
+import { requireEnv } from './utils/env.utils';
 
 test.describe('Cart functionalities (guest)', () => {
   /**
@@ -55,12 +56,8 @@ test.describe('Cart functionalities (guest)', () => {
     await test.step('Log in with account', async () =>{
       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
       const loginPage = new LoginPage(page);
-      let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-      let passwordInputValue = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-      if(!emailInputValue || !passwordInputValue) {
-        throw new Error("MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} and/or MAGENTO_EXISTING_ACCOUNT_PASSWORD have not defined in the .env file, or the account hasn't been created yet.");
-      }
+      const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
+      const passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
 
       await loginPage.login(emailInputValue, passwordInputValue);
     });
@@ -114,11 +111,7 @@ test.describe('Cart functionalities (guest)', () => {
   test('Add coupon code in cart',{ tag: ['@cart', '@coupon-code', '@cold']}, async ({page, browserName}) => {
     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
     const cart = new CartPage(page);
-    let discountCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
-
-    if(!discountCode) {
-      throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} appears to not be set in .env file. Value reported: ${discountCode}`);
-    }
+    const discountCode = requireEnv(`MAGENTO_COUPON_CODE_${browserEngine}`);
 
     await cart.applyDiscountCode(discountCode);
   });
@@ -139,11 +132,7 @@ test.describe('Cart functionalities (guest)', () => {
   test('Remove coupon code from cart',{ tag: ['@cart', '@coupon-code', '@cold'] }, async ({page, browserName}) => {
     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
     const cart = new CartPage(page);
-    let discountCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
-
-    if(!discountCode) {
-      throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} appears to not be set in .env file. Value reported: ${discountCode}`);
-    }
+    const discountCode = requireEnv(`MAGENTO_COUPON_CODE_${browserEngine}`);
 
     await cart.applyDiscountCode(discountCode);
     await cart.removeDiscountCode();

--- a/tests/checkout.spec.ts
+++ b/tests/checkout.spec.ts
@@ -6,6 +6,7 @@ import { UIReference, slugs } from 'config';
 import LoginPage from './poms/frontend/login.page';
 import ProductPage from './poms/frontend/product.page';
 import AccountPage from './poms/frontend/account.page';
+import { requireEnv } from './utils/env.utils';
 import CheckoutPage from './poms/frontend/checkout.page';
 
 
@@ -33,12 +34,8 @@ test.describe('Checkout (login required)', () => {
   // Before each test, log in
   test.beforeEach(async ({ page, browserName }) => {
     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-    let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-    let passwordInputValue = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-    if(!emailInputValue || !passwordInputValue) {
-      throw new Error("MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} and/or MAGENTO_EXISTING_ACCOUNT_PASSWORD have not defined in the .env file, or the account hasn't been created yet.");
-    }
+    const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
+    const passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
 
     const loginPage = new LoginPage(page);
     await loginPage.login(emailInputValue, passwordInputValue);
@@ -116,11 +113,7 @@ test.describe('Checkout (guest)', () => {
     test('Add coupon code in checkout',{ tag: ['@checkout', '@coupon-code', '@cold']}, async ({page, browserName}) => {
       const checkout = new CheckoutPage(page);
       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-      let discountCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
-
-      if(!discountCode) {
-        throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} appears to not be set in .env file. Value reported: ${discountCode}`);
-      }
+      const discountCode = requireEnv(`MAGENTO_COUPON_CODE_${browserEngine}`);
 
       await checkout.applyDiscountCodeCheckout(discountCode);
     });
@@ -163,11 +156,7 @@ test.describe('Checkout (guest)', () => {
   test('Remove coupon code from checkout',{ tag: ['@checkout', '@coupon-code', '@cold']}, async ({page, browserName}) => {
     const checkout = new CheckoutPage(page);
     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-    let discountCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
-
-    if(!discountCode) {
-      throw new Error(`MAGENTO_COUPON_CODE appears to not be set in .env file. Value reported: ${discountCode}`);
-    }
+    const discountCode = requireEnv(`MAGENTO_COUPON_CODE_${browserEngine}`);
 
     await checkout.applyDiscountCodeCheckout(discountCode);
     await checkout.removeDiscountCode();

--- a/tests/compare.spec.ts
+++ b/tests/compare.spec.ts
@@ -6,6 +6,7 @@ import { UIReference, outcomeMarker, slugs } from 'config';
 import ComparePage from './poms/frontend/compare.page';
 import LoginPage from './poms/frontend/login.page';
 import ProductPage from './poms/frontend/product.page';
+import { requireEnv } from './utils/env.utils';
 
 // TODO: Create a fixture for this
 test.beforeEach('Add 2 products to compare, then navigate to comparison page', async ({ page }) => {
@@ -63,12 +64,8 @@ test('Add_product_to_wishlist_from_comparison_page',{ tag: ['@comparison-page', 
   await test.step('Log in with account', async () =>{
     const loginPage = new LoginPage(page);
     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-    let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-    let passwordInputValue = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-    if(!emailInputValue || !passwordInputValue) {
-      throw new Error("MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} and/or MAGENTO_EXISTING_ACCOUNT_PASSWORD have not defined in the .env file, or the account hasn't been created yet.");
-    }
+    const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
+    const passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
 
     await loginPage.login(emailInputValue, passwordInputValue);
   });

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -2,18 +2,16 @@
 
 import { test as base, expect } from '@playwright/test';
 import { outcomeMarker, inputValues } from 'config';
+import { requireEnv } from './utils/env.utils';
 
 import LoginPage from './poms/frontend/login.page';
 
 base('User can log in with valid credentials', {tag: '@hot'}, async ({page, browserName}) => {
   const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-
-  let passwordInputValue = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-  if(!emailInputValue || !passwordInputValue) {
-    throw new Error("MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} and/or MAGENTO_EXISTING_ACCOUNT_PASSWORD have not defined in the .env file, or the account hasn't been created yet.");
-  }
+  // We can't move this browser specific check inside LoginPage because the
+  // variable name differs per browser engine.
+  const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
+  const passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
 
   const loginPage = new LoginPage(page)
   await loginPage.login(emailInputValue, passwordInputValue);

--- a/tests/mainmenu.spec.ts
+++ b/tests/mainmenu.spec.ts
@@ -6,18 +6,15 @@ import { UIReference, slugs } from 'config';
 import LoginPage from './poms/frontend/login.page';
 import MainMenuPage from './poms/frontend/mainmenu.page';
 import ProductPage from './poms/frontend/product.page';
+import { requireEnv } from './utils/env.utils';
 
 // no resetting storageState, mainmenu has more functionalities when logged in.
 
 // Before each test, log in
 test.beforeEach(async ({ page, browserName }) => {
   const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-  let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-  let passwordInputValue = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-  if(!emailInputValue || !passwordInputValue) {
-    throw new Error("MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} and/or MAGENTO_EXISTING_ACCOUNT_PASSWORD have not defined in the .env file, or the account hasn't been created yet.");
-  }
+  const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
+  const passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
 
   const loginPage = new LoginPage(page);
   await loginPage.login(emailInputValue, passwordInputValue);

--- a/tests/product.spec.ts
+++ b/tests/product.spec.ts
@@ -5,6 +5,7 @@ import { UIReference ,slugs } from 'config';
 
 import ProductPage from './poms/frontend/product.page';
 import LoginPage from './poms/frontend/login.page';
+import { requireEnv } from './utils/env.utils';
 
 test.describe('Product page tests',{ tag: '@product',}, () => {
   test('Add product to compare',{ tag: '@cold'}, async ({page}) => {
@@ -15,12 +16,8 @@ test.describe('Product page tests',{ tag: '@product',}, () => {
   test('Add product to wishlist',{ tag: '@cold'}, async ({page, browserName}) => {
     await test.step('Log in with account', async () =>{
       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
-      let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-      let passwordInputValue = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-      if(!emailInputValue || !passwordInputValue) {
-        throw new Error("MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} and/or MAGENTO_EXISTING_ACCOUNT_PASSWORD have not defined in the .env file, or the account hasn't been created yet.");
-      }
+      const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
+      const passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
 
       const loginPage = new LoginPage(page);
       await loginPage.login(emailInputValue, passwordInputValue);

--- a/tests/register.spec.ts
+++ b/tests/register.spec.ts
@@ -5,6 +5,7 @@ import {faker} from '@faker-js/faker';
 import { inputValues } from 'config';
 
 import RegisterPage from './poms/frontend/register.page';
+import { requireEnv } from './utils/env.utils';
 
 // Reset storageState to ensure we're not logged in before running these tests.
 test.use({ storageState: { cookies: [], origins: [] } });
@@ -22,7 +23,7 @@ test('User can register an account', { tag: ['@setup', '@hot'] }, async ({page, 
   const registerPage = new RegisterPage(page);
 
   // Retrieve desired password from .env file
-  const existingAccountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
+  const existingAccountPassword = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
   var firstName = faker.person.firstName();
   var lastName = faker.person.lastName();
 
@@ -33,10 +34,8 @@ test('User can register an account', { tag: ['@setup', '@hot'] }, async ({page, 
   const accountEmail = `${emailHandle}${randomNumber}-${browserEngine}@${emailHost}`;
   //const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
 
-  if (!accountEmail || !existingAccountPassword) {
-    throw new Error(
-      `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
-    );
+  if (!accountEmail) {
+    throw new Error(`Generated account email is invalid.`);
   }
   // end of browserNameEmailSection
 

--- a/tests/setup.spec.ts
+++ b/tests/setup.spec.ts
@@ -7,6 +7,7 @@ import { toggles, inputValues } from 'config';
 
 import MagentoAdminPage from './poms/adminhtml/magentoAdmin.page';
 import RegisterPage from './poms/frontend/register.page';
+import { requireEnv } from './utils/env.utils';
 
 /**
  * NOTE:
@@ -18,12 +19,8 @@ import RegisterPage from './poms/frontend/register.page';
 const runSetupTests = (describeFn: typeof base.describe | typeof base.describe.only) => {
   describeFn('Setting up the testing environment', () => {
     base('Enable multiple Magento admin logins', { tag: '@setup' }, async ({ page, browserName }, testInfo) => {
-      const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-      const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
-
-      if (!magentoAdminUsername || !magentoAdminPassword) {
-        throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-      }
+      const magentoAdminUsername = requireEnv('MAGENTO_ADMIN_USERNAME');
+      const magentoAdminPassword = requireEnv('MAGENTO_ADMIN_PASSWORD');
 
       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
 
@@ -37,12 +34,8 @@ const runSetupTests = (describeFn: typeof base.describe | typeof base.describe.o
     });
 
     base('Disable login CAPTCHA', { tag: '@setup' }, async ({ page, browserName }, testInfo) => {
-      const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-      const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
-
-      if (!magentoAdminUsername || !magentoAdminPassword) {
-        throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-      }
+      const magentoAdminUsername = requireEnv('MAGENTO_ADMIN_USERNAME');
+      const magentoAdminPassword = requireEnv('MAGENTO_ADMIN_PASSWORD');
 
       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
 
@@ -65,31 +58,18 @@ const runSetupTests = (describeFn: typeof base.describe | typeof base.describe.o
       }
 
       await base.step(`Step 1: Perform actions`, async () => {
-        const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
-        const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
-
-        if (!magentoAdminUsername || !magentoAdminPassword) {
-          throw new Error("MAGENTO_ADMIN_USERNAME or MAGENTO_ADMIN_PASSWORD is not defined in your .env file.");
-        }
+        const magentoAdminUsername = requireEnv('MAGENTO_ADMIN_USERNAME');
+        const magentoAdminPassword = requireEnv('MAGENTO_ADMIN_PASSWORD');
 
         const magentoAdminPage = new MagentoAdminPage(page);
         await magentoAdminPage.login(magentoAdminUsername, magentoAdminPassword);
 
-        const couponCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
-        if (!couponCode) {
-          throw new Error(`MAGENTO_COUPON_CODE_${browserEngine} is not defined in your .env file.`);
-        }
+        const couponCode = requireEnv(`MAGENTO_COUPON_CODE_${browserEngine}`);
         await magentoAdminPage.addCartPriceRule(couponCode);
 
         const registerPage = new RegisterPage(page);
-        const accountEmail = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
-        const accountPassword = process.env.MAGENTO_EXISTING_ACCOUNT_PASSWORD;
-
-        if (!accountEmail || !accountPassword) {
-          throw new Error(
-            `MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine} or MAGENTO_EXISTING_ACCOUNT_PASSWORD is not defined in your .env file.`
-          );
-        }
+        const accountEmail = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
+        const accountPassword = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
 
         await registerPage.createNewAccount(
           inputValues.accountCreation.firstNameValue,

--- a/tests/utils/env.utils.ts
+++ b/tests/utils/env.utils.ts
@@ -1,0 +1,14 @@
+// @ts-check
+
+/**
+ * Utility to retrieve required environment variables.
+ * Throws an error when the variable is not set.
+ */
+export function requireEnv(varName: string): string {
+  const value = process.env[varName];
+  if (!value) {
+    throw new Error(`${varName} is not defined in the .env file.`);
+  }
+  return value;
+}
+


### PR DESCRIPTION
## Summary
- add `requireEnv` helper to enforce env variable presence
- reuse helper in specs to reduce duplicate checks

## Testing
- `npx playwright test --workers=4 --grep-invert "@setup" --max-failures=1` *(fails: missing Playwright install)*

------
https://chatgpt.com/codex/tasks/task_e_685b97ca2914832b8b0054e7d956f40d