### PR TITLE
Rename tests for consistent naming

### DIFF
--- a/tests/account.spec.ts
+++ b/tests/account.spec.ts
@@ -43,7 +43,7 @@ test.describe('Account information actions', {annotation: {type: 'Account Dashbo
    * @then I should see a notification that my password has been updated
    * @and I should be able to login with my new credentials.
    */
-  test('I can change my password',{ tag: ['@account-credentials', '@hot'] }, async ({page, browserName}, testInfo) => {
+  test('Change_password',{ tag: ['@account-credentials', '@hot'] }, async ({page, browserName}, testInfo) => {
 
     // Create instances and set variables
     const mainMenu = new MainMenuPage(page);
@@ -106,7 +106,7 @@ test.describe.serial('Account address book actions', { annotation: {type: 'Accou
    *  @and The new address should be selected as default and shipping address
    */
 
-  test('I can add my first address',{ tag: ['@account-credentials', '@hot'] }, async ({page}, testInfo) => {
+  test('Add_first_address',{ tag: ['@account-credentials', '@hot'] }, async ({page}, testInfo) => {
     const accountPage = new AccountPage(page);
     let addNewAddressTitle = page.getByRole('heading', {level: 1, name: UIReference.newAddress.addNewAddressTitle});
 
@@ -128,7 +128,7 @@ test.describe.serial('Account address book actions', { annotation: {type: 'Accou
    * @then I should see a notification my address has been updated.
    *  @and The new address should be listed
    */
-  test('I can add another address',{ tag: ['@account-credentials', '@hot'] }, async ({page}) => {
+  test('Add_another_address',{ tag: ['@account-credentials', '@hot'] }, async ({page}) => {
     await page.goto(slugs.account.addressNewSlug);
     const accountPage = new AccountPage(page);
 
@@ -147,7 +147,7 @@ test.describe.serial('Account address book actions', { annotation: {type: 'Accou
    * @then I should see a notification my address has been updated.
    *  @and The updated address should be visible in the addres book page.
    */
-  test('I can edit an existing address',{ tag: ['@account-credentials', '@hot'] }, async ({page}) => {
+  test('Edit_existing_address',{ tag: ['@account-credentials', '@hot'] }, async ({page}) => {
     const accountPage = new AccountPage(page);
     await page.goto(slugs.account.addressNewSlug);
     let editAddressButton = page.getByRole('link', {name: UIReference.accountDashboard.editAddressIconButton}).first();
@@ -172,7 +172,7 @@ test.describe.serial('Account address book actions', { annotation: {type: 'Accou
    * @then I should see a notification my address has been deleted.
    *  @and The address should be removed from the overview.
    */
-  test('I can delete an address',{ tag: ['@account-credentials', '@hot'] }, async ({page}, testInfo) => {
+  test('Delete_an_address',{ tag: ['@account-credentials', '@hot'] }, async ({page}, testInfo) => {
     const accountPage = new AccountPage(page);
 
     let deleteAddressButton = page.getByRole('link', {name: UIReference.accountDashboard.addressDeleteIconButton}).first();
@@ -201,7 +201,7 @@ test.describe('Newsletter actions', { annotation: {type: 'Account Dashboard', de
    *  @then I should see a message confirming my action
    *  @and My subscription option should be updated.
    */
-  test('I can update my newsletter subscription',{ tag: ['@newsletter-actions', '@cold'] }, async ({page, browserName}) => {
+  test('Update_newsletter_subscription',{ tag: ['@newsletter-actions', '@cold'] }, async ({page, browserName}) => {
     test.skip(browserName === 'webkit', '.click() does not work, still searching for a workaround');
     const newsletterPage = new NewsletterSubscriptionPage(page);
     let newsletterLink = page.getByRole('link', { name: UIReference.accountDashboard.links.newsletterLink });

--- a/tests/cart.spec.ts
+++ b/tests/cart.spec.ts
@@ -40,7 +40,7 @@ test.describe('Cart functionalities (guest)', () => {
    *  @and I am on the cart page
    * @then I should see the name of the product in my cart
    */
-  test('Product can be added to cart',{ tag: ['@cart', '@cold'],}, async ({page}) => {
+  test('Add_product_to_cart',{ tag: ['@cart', '@cold'],}, async ({page}) => {
     await expect(page.getByRole('strong').getByRole('link', {name: UIReference.productPage.simpleProductTitle}), `Product is visible in cart`).toBeVisible();
   });
 
@@ -51,7 +51,7 @@ test.describe('Cart functionalities (guest)', () => {
    * @when I log in
    * @then I should still have that product in my cart
    */
-  test('Product should remain in cart after logging in',{ tag: ['@cart', '@account', '@hot']}, async ({page, browserName}) => {
+  test('Product_remains_in_cart_after_login',{ tag: ['@cart', '@account', '@hot']}, async ({page, browserName}) => {
     await test.step('Add another product to cart', async () =>{
       const productpage = new ProductPage(page);
       await page.goto(slugs.productpage.secondSimpleProductSlug);
@@ -85,7 +85,7 @@ test.describe('Cart functionalities (guest)', () => {
    * @then I should see a notification that the product has been removed from my cart
    *  @and I should no longer see the product in my cart
    */
-  test('Remove product from cart',{ tag: ['@cart','@cold'],}, async ({page}) => {
+  test('Remove_product_from_cart',{ tag: ['@cart','@cold'],}, async ({page}) => {
     const cart = new CartPage(page);
     await cart.removeProduct(UIReference.productPage.simpleProductTitle);
   });
@@ -100,7 +100,7 @@ test.describe('Cart functionalities (guest)', () => {
    * @then the quantity field should have the new amount
    * @and the subtotal/grand total should update
    */
-  test('Change quantity of products in cart',{ tag: ['@cart', '@cold'],}, async ({page}) => {
+  test('Change_product_quantity_in_cart',{ tag: ['@cart', '@cold'],}, async ({page}) => {
     const cart = new CartPage(page);
     await cart.changeProductQuantity('2');
   });
@@ -117,7 +117,7 @@ test.describe('Cart functionalities (guest)', () => {
    *  @and the code should be visible in the cart
    *  @and a discount should be applied to the product
    */
-  test('Add coupon code in cart',{ tag: ['@cart', '@coupon-code', '@cold']}, async ({page, browserName}) => {
+  test('Add_coupon_code_in_cart',{ tag: ['@cart', '@coupon-code', '@cold']}, async ({page, browserName}) => {
     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
     const cart = new CartPage(page);
     let discountCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
@@ -142,7 +142,7 @@ test.describe('Cart functionalities (guest)', () => {
    * @then I should see a notification the discount has been removed
    * @and the discount should no longer be visible.
    */
-  test('Remove coupon code from cart',{ tag: ['@cart', '@coupon-code', '@cold'] }, async ({page, browserName}) => {
+  test('Remove_coupon_code_from_cart',{ tag: ['@cart', '@coupon-code', '@cold'] }, async ({page, browserName}) => {
     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
     const cart = new CartPage(page);
     let discountCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
@@ -164,7 +164,7 @@ test.describe('Cart functionalities (guest)', () => {
    * @then I should get a notification that the code did not work.
    */
 
-  test('Using an invalid coupon code should give an error',{ tag: ['@cart', '@coupon-code', '@cold'] }, async ({page}) => {
+  test('Invalid_coupon_code_is_rejected',{ tag: ['@cart', '@coupon-code', '@cold'] }, async ({page}) => {
     const cart = new CartPage(page);
     await cart.enterWrongCouponCode("Incorrect Coupon Code");
   });
@@ -186,7 +186,7 @@ test.describe('Price checking tests', () => {
    * @then the amount of the product should be the same
    *  @and the price in the checkout should equal the price of the product * the amount of the product
    */
-  test('Simple product input to cart is consistent from PDP to checkout',{ tag: ['@cart-price-check', '@cold']}, async ({page}) => {
+  test('Simple_product_cart_data_consistent_from_PDP_to_checkout',{ tag: ['@cart-price-check', '@cold']}, async ({page}) => {
     var productPagePrice: string;
     var productPageAmount: string;
     var checkoutProductDetails: string[];
@@ -228,7 +228,7 @@ test.describe('Price checking tests', () => {
    * @then the amount of the product should be the same
    *  @and the price in the checkout should equal the price of the product * the amount of the product
    */
-  test('Configurable product input to cart is consistent from PDP to checkout',{ tag: ['@cart-price-check', '@cold']}, async ({page}) => {
+  test('Configurable_product_cart_data_consistent_from_PDP_to_checkout',{ tag: ['@cart-price-check', '@cold']}, async ({page}) => {
     var productPagePrice: string;
     var productPageAmount: string;
     var checkoutProductDetails: string[];

--- a/tests/checkout.spec.ts
+++ b/tests/checkout.spec.ts
@@ -53,7 +53,7 @@ test.describe('Checkout (login required)', () => {
    *  @and I have navigated to the checkout page
    * @then My name and address should already be filled in
    */
-  test('My address should be already filled in at the checkout',{ tag: ['@checkout', '@hot']}, async ({page}) => {
+  test('Address_is_pre_filled_in_checkout',{ tag: ['@checkout', '@hot']}, async ({page}) => {
     let signInLink = page.getByRole('link', { name: UIReference.credentials.loginButtonLabel });
     let addressField = page.getByLabel(UIReference.newAddress.streetAddressLabel);
     let addressAlreadyAdded = false;
@@ -93,7 +93,7 @@ test.describe('Checkout (login required)', () => {
    * @then I should see a confirmation that my order has been placed
    *  @and a order number should be created and show to me
    */
-  test('Place order for simple product',{ tag: ['@simple-product-order', '@hot'],}, async ({page}, testInfo) => {
+  test('Place_order_for_simple_product',{ tag: ['@simple-product-order', '@hot'],}, async ({page}, testInfo) => {
     const checkoutPage = new CheckoutPage(page);
     let orderNumber = await checkoutPage.placeOrder();
     testInfo.annotations.push({ type: 'Order number', description: `${orderNumber}` });
@@ -113,7 +113,7 @@ test.describe('Checkout (guest)', () => {
    *  @and the code should be visible in the cart
    *  @and a discount should be applied to the product
    */
-    test('Add coupon code in checkout',{ tag: ['@checkout', '@coupon-code', '@cold']}, async ({page, browserName}) => {
+    test('Add_coupon_code_in_checkout',{ tag: ['@checkout', '@coupon-code', '@cold']}, async ({page, browserName}) => {
       const checkout = new CheckoutPage(page);
       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
       let discountCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
@@ -125,7 +125,7 @@ test.describe('Checkout (guest)', () => {
       await checkout.applyDiscountCodeCheckout(discountCode);
     });
 
-    test('Verify price calculations in checkout', { tag: ['@checkout', '@price-calculation'] }, async ({ page }) => {
+    test('Verify_price_calculations_in_checkout', { tag: ['@checkout', '@price-calculation'] }, async ({ page }) => {
       const productPage = new ProductPage(page);
       const checkoutPage = new CheckoutPage(page);
 
@@ -160,7 +160,7 @@ test.describe('Checkout (guest)', () => {
    * @and the discount should no longer be visible.
    */
 
-  test('Remove coupon code from checkout',{ tag: ['@checkout', '@coupon-code', '@cold']}, async ({page, browserName}) => {
+  test('Remove_coupon_code_from_checkout',{ tag: ['@checkout', '@coupon-code', '@cold']}, async ({page, browserName}) => {
     const checkout = new CheckoutPage(page);
     const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
     let discountCode = process.env[`MAGENTO_COUPON_CODE_${browserEngine}`];
@@ -182,7 +182,7 @@ test.describe('Checkout (guest)', () => {
    * @then I should get a notification that the code did not work.
    */
 
-  test('Using an invalid coupon code should give an error',{ tag: ['@checkout', '@coupon-code', '@cold'] }, async ({page}) => {
+  test('Invalid_coupon_code_in_checkout_is_rejected',{ tag: ['@checkout', '@coupon-code', '@cold'] }, async ({page}) => {
     const checkout = new CheckoutPage(page);
     await checkout.enterWrongCouponCode("incorrect discount code");
   });
@@ -197,7 +197,7 @@ test.describe('Checkout (guest)', () => {
    * @then I should see a confirmation that my order has been placed
    *  @and a order number should be created and shown to me
    */
-  test('Guest can select different payment methods', { tag: ['@checkout', '@payment-methods', '@cold'] }, async ({ page }) => {
+  test('Guest_can_select_payment_methods', { tag: ['@checkout', '@payment-methods', '@cold'] }, async ({ page }) => {
     const checkoutPage = new CheckoutPage(page);
 
     // Test with check/money order payment

--- a/tests/contact.spec.ts
+++ b/tests/contact.spec.ts
@@ -13,7 +13,7 @@ import ContactPage from './poms/frontend/contact.page';
  *  @then I should see a notification my message has been sent
  *  @and the fields should be empty again.
  */
-test('I can send a message through the contact form',{ tag: ['@contact-form', '@cold']}, async ({page}) => {
+test('Send_message_through_contact_form',{ tag: ['@contact-form', '@cold']}, async ({page}) => {
   const contactPage = new ContactPage(page);
   await contactPage.fillOutForm();
 });

--- a/tests/healthcheck.spec.ts
+++ b/tests/healthcheck.spec.ts
@@ -5,7 +5,7 @@ import { UIReference, slugs, toggles} from 'config';
 
 if ( toggles.general.pageHealthCheck ) {
   test.describe('Page health checks', () => {
-    test('Homepage returns 200', { tag: ['@healthcheck','@cold'] }, async ({ page }) => {
+    test('Homepage_returns_200', { tag: ['@healthcheck','@cold'] }, async ({ page }) => {
       const homepageURL = process.env.PLAYWRIGHT_BASE_URL || process.env.BASE_URL;
       if (!homepageURL) {
         throw new Error("PLAYWRIGHT_BASE_URL has not been defined in the .env file.");
@@ -22,7 +22,7 @@ if ( toggles.general.pageHealthCheck ) {
       ).toBeVisible();
     });
 
-    test('PLP returns 200', { tag: ['@healthcheck','@cold'] }, async ({ page }) => {
+    test('Plp_returns_200', { tag: ['@healthcheck','@cold'] }, async ({ page }) => {
       const plpResponsePromise = page.waitForResponse(slugs.categoryPage.categorySlug);
       await page.goto(slugs.categoryPage.categorySlug);
       const plpResponse = await plpResponsePromise;
@@ -34,7 +34,7 @@ if ( toggles.general.pageHealthCheck ) {
       ).toBeVisible();
     });
 
-    test('PDP returns 200', { tag: ['@healthcheck','@cold']  }, async ({ page }) => {
+    test('Pdp_returns_200', { tag: ['@healthcheck','@cold']  }, async ({ page }) => {
       const pdpResponsePromise = page.waitForResponse(slugs.productpage.simpleProductSlug);
       await page.goto(slugs.productpage.simpleProductSlug);
       const pdpResponse = await pdpResponsePromise;
@@ -46,7 +46,7 @@ if ( toggles.general.pageHealthCheck ) {
       ).toBeVisible();
     });
 
-    test('Checkout returns 200', { tag: ['@healthcheck','@cold']  }, async ({ page }) => {
+    test('Checkout_returns_200', { tag: ['@healthcheck','@cold']  }, async ({ page }) => {
       const responsePromise = page.waitForResponse(slugs.checkout.checkoutSlug);
 
       await page.goto(slugs.checkout.checkoutSlug);

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -6,7 +6,7 @@ import { outcomeMarker } from 'config';
 import MainMenuPage from './poms/frontend/mainmenu.page';
 import HomePage from './poms/frontend/home.page';
 
-test('Add product on homepage to cart',{ tag: ['@homepage', '@cold']}, async ({page}) => {
+test('Add_product_on_homepage_to_cart',{ tag: ['@homepage', '@cold']}, async ({page}) => {
   const homepage = new HomePage(page);
   const mainmenu = new MainMenuPage(page);
 

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -5,7 +5,7 @@ import { outcomeMarker, inputValues } from 'config';
 
 import LoginPage from './poms/frontend/login.page';
 
-base('User can log in with valid credentials', {tag: '@hot'}, async ({page, browserName}) => {
+base('User_logs_in_with_valid_credentials', {tag: '@hot'}, async ({page, browserName}) => {
   const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
   let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
 
@@ -38,12 +38,12 @@ base('User can log in with valid credentials', {tag: '@hot'}, async ({page, brow
   expect(parsedData.customer.fullname, 'Customer lastname should match').toContain(inputValues.accountCreation.lastNameValue);
 });
 
-base('User cannot log in with invalid credentials', async ({page}) => {
+base('Invalid_credentials_are_rejected', async ({page}) => {
   const loginPage = new LoginPage(page);
   await loginPage.loginExpectError('invalid@example.com', 'wrongpassword', outcomeMarker.login.invalidCredentialsMessage);
 });
 
-base('Login fails with missing password', async ({page}) => {
+base('Login_fails_with_missing_password', async ({page}) => {
   const loginPage = new LoginPage(page);
   await loginPage.loginExpectError('invalid@example.com', '', '');
 });

--- a/tests/mainmenu.spec.ts
+++ b/tests/mainmenu.spec.ts
@@ -32,18 +32,18 @@ test.beforeEach(async ({ page, browserName }) => {
  *    @and I click the Logout option
  *  @then I should see a message confirming I am logged out
  */
-test('User can log out', { tag: ['@mainmenu', '@hot'] }, async ({page}) => {
+test('User_logs_out', { tag: ['@mainmenu', '@hot'] }, async ({page}) => {
   const mainMenu = new MainMenuPage(page);
   await mainMenu.logout();
 });
 
 
-test('Navigate to account page', { tag: ['@mainmenu', '@hot'] }, async ({page}) => {
+test('Navigate_to_account_page', { tag: ['@mainmenu', '@hot'] }, async ({page}) => {
   const mainMenu = new MainMenuPage(page);
   await mainMenu.gotoMyAccount();
 });
 
-test('Open the minicart', { tag: ['@mainmenu', '@cold'] }, async ({page}, testInfo) => {
+test('Open_the_minicart', { tag: ['@mainmenu', '@cold'] }, async ({page}, testInfo) => {
   testInfo.annotations.push({ type: 'WARNING (FIREFOX)', description: `The minicart icon does not lose its aria-disabled=true flag when the first product is added. This prevents Playwright from clicking it. A fix will be added in the future.`});
 
   const mainMenu = new MainMenuPage(page);

--- a/tests/minicart.spec.ts
+++ b/tests/minicart.spec.ts
@@ -38,7 +38,7 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
    *  @then I should navigate to the checkout page
    */
 
-  test('Add product to minicart, navigate to checkout',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}) => {
+  test('Add_product_to_minicart_and_go_to_checkout',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}) => {
     const miniCart = new MiniCartPage(page);
     await miniCart.goToCheckout();
   });
@@ -51,7 +51,7 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
    * @then I should be navigated to the cart page
    */
 
-  test('Add product to minicart, navigate to cart',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}) => {
+  test('Add_product_to_minicart_and_go_to_cart',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}) => {
     const miniCart = new MiniCartPage(page);
     await miniCart.goToCart();
   });
@@ -67,7 +67,7 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
    *  @then I should see a confirmation
    *    @and the new amount should be shown in the minicart
    */
-  test('Change quantity of a product in minicart',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}) => {
+  test('Change_product_quantity_in_minicart',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}) => {
     const miniCart = new MiniCartPage(page);
     await miniCart.updateProduct('3');
   });
@@ -80,7 +80,7 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
    *  @then The product should not be in my cart anymore
    *  @and I should see a notification that the product was removed
    */
-  test('Delete product from minicart',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}, testInfo) => {
+  test('Delete_product_from_minicart',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}, testInfo) => {
     testInfo.annotations.push({ type: 'WARNING (FIREFOX)', description: `The minicart icon does not lose its aria-disabled=true flag when the first product is added. This prevents Playwright from clicking it. A fix will be added in the future.`});
     const miniCart = new MiniCartPage(page);
     await miniCart.removeProductFromMinicart(UIReference.productPage.simpleProductTitle);
@@ -92,7 +92,7 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
    * @given I have added a (simple) product to the cart and opened the minicart
    * @then the price listed in the minicart (per product) should be the same as the price on the PDP
   */
-  test('Price on PDP is the same as price in Minicart',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}) => {
+  test('Pdp_price_matches_minicart_price',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}) => {
     const miniCart = new MiniCartPage(page);
     await miniCart.checkPriceWithProductPage();
   });
@@ -126,7 +126,7 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
    * @given I have added a (configurable) product to the cart and opened the minicart
    * @then the price listed in the minicart (per product) should be the same as the price on the PDP
   */
-  test('Price configurable PDP is same as price in Minicart',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}) => {
+  test('Configurable_pdp_price_matches_minicart_price',{ tag: ['@minicart-simple-product', '@cold']}, async ({page}) => {
     const miniCart = new MiniCartPage(page);
     await miniCart.checkPriceWithProductPage();
   });

--- a/tests/product.spec.ts
+++ b/tests/product.spec.ts
@@ -7,12 +7,12 @@ import ProductPage from './poms/frontend/product.page';
 import LoginPage from './poms/frontend/login.page';
 
 test.describe('Product page tests',{ tag: '@product',}, () => {
-  test('Add product to compare',{ tag: '@cold'}, async ({page}) => {
+  test('Add_product_to_compare',{ tag: '@cold'}, async ({page}) => {
     const productPage = new ProductPage(page);
     await productPage.addProductToCompare(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
   });
 
-  test('Add product to wishlist',{ tag: '@cold'}, async ({page, browserName}) => {
+  test('Add_product_to_wishlist',{ tag: '@cold'}, async ({page, browserName}) => {
     await test.step('Log in with account', async () =>{
       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
       let emailInputValue = process.env[`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`];
@@ -38,12 +38,12 @@ test.describe('Product page tests',{ tag: '@product',}, () => {
     // await productPage.leaveProductReview(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
   });
 
-  test('Open pictures in lightbox and scroll through', async ({page}) => {
+  test('Open_pictures_in_lightbox_and_scroll', async ({page}) => {
     const productPage = new ProductPage(page);
     await productPage.openLightboxAndScrollThrough(slugs.productpage.configurableProductSlug);
   });
 
-  test('Change number of reviews shown on product page', async ({page}) => {
+  test('Change_number_of_reviews_shown_on_product_page', async ({page}) => {
     const productPage = new ProductPage(page);
     await productPage.changeReviewCountAndVerify(slugs.productpage.simpleProductSlug);
   });

--- a/tests/register.spec.ts
+++ b/tests/register.spec.ts
@@ -18,7 +18,7 @@ test.use({ storageState: { cookies: [], origins: [] } });
  *  @then I click the 'Create account' button
  *  @then I should see a messsage confirming my account was created
  */
-test('User can register an account', { tag: ['@setup', '@hot'] }, async ({page, browserName}, testInfo) => {
+test('User_registers_an_account', { tag: ['@setup', '@hot'] }, async ({page, browserName}, testInfo) => {
   const registerPage = new RegisterPage(page);
 
   // Retrieve desired password from .env file

--- a/tests/setup.spec.ts
+++ b/tests/setup.spec.ts
@@ -17,7 +17,7 @@ import RegisterPage from './poms/frontend/register.page';
 
 const runSetupTests = (describeFn: typeof base.describe | typeof base.describe.only) => {
   describeFn('Setting up the testing environment', () => {
-    base('Enable multiple Magento admin logins', { tag: '@setup' }, async ({ page, browserName }, testInfo) => {
+    base('Enable_multiple_admin_logins', { tag: '@setup' }, async ({ page, browserName }, testInfo) => {
       const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
       const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
 
@@ -36,7 +36,7 @@ const runSetupTests = (describeFn: typeof base.describe | typeof base.describe.o
       }
     });
 
-    base('Disable login CAPTCHA', { tag: '@setup' }, async ({ page, browserName }, testInfo) => {
+    base('Disable_login_captcha', { tag: '@setup' }, async ({ page, browserName }, testInfo) => {
       const magentoAdminUsername = process.env.MAGENTO_ADMIN_USERNAME;
       const magentoAdminPassword = process.env.MAGENTO_ADMIN_PASSWORD;
 
@@ -55,7 +55,7 @@ const runSetupTests = (describeFn: typeof base.describe | typeof base.describe.o
       }
     });
 
-    base('Setup Magento environment for tests', { tag: '@setup' }, async ({ page, browserName }, testInfo) => {
+    base('Setup_environment_for_tests', { tag: '@setup' }, async ({ page, browserName }, testInfo) => {
       const browserEngine = browserName?.toUpperCase() || "UNKNOWN";
       const setupCompleteVar = `SETUP_COMPLETE_${browserEngine}`;
       const isSetupComplete = process.env[setupCompleteVar];


### PR DESCRIPTION
## Summary
- rename test names to use underscores and descriptive wording

## Testing
- `npx playwright test --list` *(fails: package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685cf6ca7390832baea3a5582da9c468