### PR TITLE
Update healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ Playwright also offers a trace view. While using the UI mode is seen as the defa
 npx playwright test --trace on
 ```
 
+### Healthcheck
+To quickly check if your Magento site is up and running, execute the smoke tests with the following command:
+
+```bash
+npx playwright test --grep @smoke
+```
+
 ### Skipping specific tests
 Certain `spec` files and specific tests are used as a setup. For example, all setup tests (such as creating an account and setting a coupon code in your Magento 2 environment) have the tag ‘@setup’. Since these only have to be used once (or in the case of our demo website every 24 hours), most of the time you can skip these. These means most of the time, using the following command is best. This command skips both the `user can register an account` test, as well as the whole of `base/setup.spec.ts`.
 

--- a/tests/config/test-toggles.json
+++ b/tests/config/test-toggles.json
@@ -1,6 +1,5 @@
 {
   "general": {
-    "setup": false,
-    "pageHealthCheck": false
+    "setup": false
   }
 }

--- a/tests/healthcheck.spec.ts
+++ b/tests/healthcheck.spec.ts
@@ -1,11 +1,10 @@
 // @ts-check
 
 import { test, expect } from '@playwright/test';
-import { UIReference, slugs, toggles} from 'config';
+import { UIReference, slugs } from 'config';
 
-if ( toggles.general.pageHealthCheck ) {
-  test.describe('Page health checks', () => {
-    test('Homepage returns 200', { tag: ['@healthcheck','@cold'] }, async ({ page }) => {
+test.describe('Page health checks', () => {
+  test('Homepage returns 200', { tag: ['@smoke','@cold'] }, async ({ page }) => {
       const homepageURL = process.env.PLAYWRIGHT_BASE_URL || process.env.BASE_URL;
       if (!homepageURL) {
         throw new Error("PLAYWRIGHT_BASE_URL has not been defined in the .env file.");
@@ -22,7 +21,7 @@ if ( toggles.general.pageHealthCheck ) {
       ).toBeVisible();
     });
 
-    test('PLP returns 200', { tag: ['@healthcheck','@cold'] }, async ({ page }) => {
+  test('PLP returns 200', { tag: ['@smoke','@cold'] }, async ({ page }) => {
       const plpResponsePromise = page.waitForResponse(slugs.categoryPage.categorySlug);
       await page.goto(slugs.categoryPage.categorySlug);
       const plpResponse = await plpResponsePromise;
@@ -34,7 +33,7 @@ if ( toggles.general.pageHealthCheck ) {
       ).toBeVisible();
     });
 
-    test('PDP returns 200', { tag: ['@healthcheck','@cold']  }, async ({ page }) => {
+  test('PDP returns 200', { tag: ['@smoke','@cold']  }, async ({ page }) => {
       const pdpResponsePromise = page.waitForResponse(slugs.productpage.simpleProductSlug);
       await page.goto(slugs.productpage.simpleProductSlug);
       const pdpResponse = await pdpResponsePromise;
@@ -46,7 +45,7 @@ if ( toggles.general.pageHealthCheck ) {
       ).toBeVisible();
     });
 
-    test('Checkout returns 200', { tag: ['@healthcheck','@cold']  }, async ({ page }) => {
+  test('Checkout returns 200', { tag: ['@smoke','@cold']  }, async ({ page }) => {
       const responsePromise = page.waitForResponse(slugs.checkout.checkoutSlug);
 
       await page.goto(slugs.checkout.checkoutSlug);
@@ -63,4 +62,3 @@ if ( toggles.general.pageHealthCheck ) {
       expect((await page.request.head(page.url())).status(), `Current page (${page.url()}) should return 200`).toBe(200);
     });
   });
-}


### PR DESCRIPTION
## Summary
- remove deprecated `pageHealthCheck` toggle
- rename `@healthcheck` tag to `@smoke`
- add healthcheck section in README

## Testing
- `npx playwright test --grep @smoke --list` *(fails: Need to install Playwright)*

------
https://chatgpt.com/codex/tasks/task_e_685d12f070ac832b97c59a6201625d80