### PR TITLE
Add order history test

### DIFF
--- a/tests/config/slugs.json
+++ b/tests/config/slugs.json
@@ -7,7 +7,8 @@
     "accountEditSlug": "/customer/account/edit/",
     "changePasswordSlug": "/customer/account/edit/changepass/1/",
     "createAccountSlug": "/customer/account/create",
-    "loginSlug": "/customer/account/login"
+    "loginSlug": "/customer/account/login",
+    "orderHistorySlug": "/sales/order/history/"
   },
   "cart": {
     "cartProductChangeSlug": "/cart/configure/",

--- a/tests/orderhistory.spec.ts
+++ b/tests/orderhistory.spec.ts
@@ -1,0 +1,33 @@
+// @ts-check
+
+import { test } from '@playwright/test';
+import { UIReference, slugs } from 'config';
+import { requireEnv } from './utils/env.utils';
+
+import LoginPage from './poms/frontend/login.page';
+import ProductPage from './poms/frontend/product.page';
+import CheckoutPage from './poms/frontend/checkout.page';
+import OrderHistoryPage from './poms/frontend/orderhistory.page';
+
+test('Recent_order_is_visible_in_history', async ({ page, browserName }) => {
+  const browserEngine = browserName?.toUpperCase() || 'UNKNOWN';
+  const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
+  const passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
+
+  const loginPage = new LoginPage(page);
+  const productPage = new ProductPage(page);
+  const checkoutPage = new CheckoutPage(page);
+  const orderHistoryPage = new OrderHistoryPage(page);
+
+  await loginPage.login(emailInputValue, passwordInputValue);
+
+  await page.goto(slugs.productpage.simpleProductSlug);
+  await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
+  await page.goto(slugs.checkout.checkoutSlug);
+  const orderNumberLocator = await checkoutPage.placeOrder();
+  const orderNumberText = await orderNumberLocator.innerText();
+  const orderNumber = orderNumberText.replace(/\D/g, '');
+
+  await orderHistoryPage.open();
+  await orderHistoryPage.verifyOrderPresent(orderNumber);
+});

--- a/tests/poms/frontend/orderhistory.page.ts
+++ b/tests/poms/frontend/orderhistory.page.ts
@@ -1,0 +1,23 @@
+// @ts-check
+
+import { expect, type Page } from '@playwright/test';
+import { slugs } from 'config';
+
+class OrderHistoryPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async open() {
+    await this.page.goto(slugs.account.orderHistorySlug);
+    await this.page.waitForLoadState();
+  }
+
+  async verifyOrderPresent(orderNumber: string) {
+    await expect(this.page.getByText(orderNumber)).toBeVisible();
+  }
+}
+
+export default OrderHistoryPage;


### PR DESCRIPTION
## Summary
- add slug for order history page
- create OrderHistoryPage fixture
- test visibility of recent order in history

## Testing
- `npx playwright --version`

------
https://chatgpt.com/codex/tasks/task_e_6863b73cd844832b8cefb5311b6fae31