### PR TITLE
Move navigation logic to page objects

### DIFF
--- a/tests/account.spec.ts
+++ b/tests/account.spec.ts
@@ -24,8 +24,8 @@ test.beforeEach(async ({ page, browserName }) => {
 test.describe('Account information actions', {annotation: {type: 'Account Dashboard', description: 'Test for Account Information'},}, () => {
 
   test.beforeEach(async ({page}) => {
-    await page.goto(slugs.account.accountOverviewSlug);
-    await page.waitForLoadState();
+    const accountPage = new AccountPage(page);
+    await accountPage.openAccountOverview();
   });
 
   /**
@@ -64,8 +64,7 @@ test.describe('Account information actions', {annotation: {type: 'Account Dashbo
     await registerPage.createNewAccount(faker.person.firstName(), faker.person.lastName(), emailPasswordUpdatevalue, passwordInputValue);
 
     // Update password
-    await page.goto(slugs.account.changePasswordSlug);
-    await page.waitForLoadState();
+    await accountPage.openChangePassword();
     await accountPage.updatePassword(passwordInputValue, changedPasswordValue);
 
     // If login with changePasswordValue is possible, then password change was succesful.
@@ -110,8 +109,7 @@ test.describe('Account information actions', {annotation: {type: 'Account Dashbo
 
     await registerPage.createNewAccount(faker.person.firstName(), faker.person.lastName(), originalEmail, passwordInputValue);
 
-    await page.goto(slugs.account.accountEditSlug);
-    await page.waitForLoadState();
+    await accountPage.openAccountEdit();
     await accountPage.updateEmail(passwordInputValue, updatedEmail);
 
     await mainMenu.logout();
@@ -148,7 +146,7 @@ test.describe.serial('Account address book actions', { annotation: {type: 'Accou
     if(await addNewAddressTitle.isHidden()) {
       await accountPage.deleteAllAddresses();
       testInfo.annotations.push({ type: 'Notification: deleted addresses', description: `All addresses are deleted to recreate the first address flow.` });
-      await page.goto(slugs.account.addressNewSlug);
+      await accountPage.openAddressNew();
     }
 
     const firstAddress = inputValues.firstAddress;
@@ -178,8 +176,8 @@ test.describe.serial('Account address book actions', { annotation: {type: 'Accou
    *  @and The new address should be listed
    */
   test('Add_another_address',{ tag: ['@account-credentials', '@hot'] }, async ({page}) => {
-    await page.goto(slugs.account.addressNewSlug);
     const accountPage = new AccountPage(page);
+    await accountPage.openAddressNew();
 
     const secondAddress = inputValues.secondAddress;
     const companyName = faker.company.name();
@@ -212,7 +210,7 @@ test.describe.serial('Account address book actions', { annotation: {type: 'Accou
    */
   test('Edit_existing_address',{ tag: ['@account-credentials', '@hot'] }, async ({page}) => {
     const accountPage = new AccountPage(page);
-    await page.goto(slugs.account.addressNewSlug);
+    await accountPage.openAddressNew();
     let editAddressButton = page.getByRole('link', {name: UIReference.accountDashboard.editAddressIconButton}).first();
 
     if(await editAddressButton.isHidden()){
@@ -220,7 +218,7 @@ test.describe.serial('Account address book actions', { annotation: {type: 'Accou
       await accountPage.addNewAddress();
     }
 
-    await page.goto(slugs.account.addressBookSlug);
+    await accountPage.openAddressBook();
     const editAddress = inputValues.editedAddress;
     const companyName = faker.company.name();
     const streetValue = editAddress.editStreetAddressValue + ' ' + Math.floor(Math.random() * 100 + 1);
@@ -239,8 +237,8 @@ test.describe.serial('Account address book actions', { annotation: {type: 'Accou
   });
 
   test('Missing_required_field_prevents_creation',{ tag: ['@account-credentials'] }, async ({page}) => {
-    await page.goto(slugs.account.addressNewSlug);
     const accountPage = new AccountPage(page);
+    await accountPage.openAddressNew();
 
     await accountPage.phoneNumberField.fill(inputValues.firstAddress.firstPhoneNumberValue);
     await accountPage.saveAddressButton.click();
@@ -267,7 +265,7 @@ test.describe.serial('Account address book actions', { annotation: {type: 'Accou
     let deleteAddressButton = page.getByRole('link', {name: UIReference.accountDashboard.addressDeleteIconButton}).first();
 
     if(await deleteAddressButton.isHidden()) {
-      await page.goto(slugs.account.addressNewSlug);
+      await accountPage.openAddressNew();
       await accountPage.addNewAddress();
     }
     await accountPage.deleteFirstAddressFromAddressBook();

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -3,6 +3,7 @@
 import { test as setup, expect } from '@playwright/test';
 import path from 'path';
 import { UIReference, slugs } from 'config';
+import LoginPage from './poms/frontend/login.page';
 import { requireEnv } from './utils/env.utils';
 
 const authFile = path.join(__dirname, '../playwright/.auth/user.json');
@@ -12,11 +13,8 @@ setup('authenticate', async ({ page, browserName }) => {
   const emailInputValue = requireEnv(`MAGENTO_EXISTING_ACCOUNT_EMAIL_${browserEngine}`);
   const passwordInputValue = requireEnv('MAGENTO_EXISTING_ACCOUNT_PASSWORD');
 
-  // Perform authentication steps. Replace these actions with your own.
-  await page.goto(slugs.account.loginSlug);
-  await page.getByLabel(UIReference.credentials.emailFieldLabel, {exact: true}).fill(emailInputValue);
-  await page.getByLabel(UIReference.credentials.passwordFieldLabel, {exact: true}).fill(passwordInputValue);
-  await page.getByRole('button', { name: UIReference.credentials.loginButtonLabel }).click();
+  const loginPage = new LoginPage(page);
+  await loginPage.login(emailInputValue, passwordInputValue);
   // Wait until the page receives the cookies.
   //
   // Sometimes login flow sets cookies in the process of several redirects.

--- a/tests/cart.spec.ts
+++ b/tests/cart.spec.ts
@@ -31,7 +31,8 @@ test.describe('Cart functionalities (guest)', () => {
 
     // await mainMenu.openMiniCart();
     // await expect(page.getByText(outcomeMarker.miniCart.simpleProductInCartTitle)).toBeVisible();
-    await page.goto(slugs.cart.cartSlug);
+    const cartPage = new CartPage(page);
+    await cartPage.openCart();
   });
 
   /**
@@ -55,7 +56,6 @@ test.describe('Cart functionalities (guest)', () => {
   test('Product_remains_in_cart_after_login',{ tag: ['@cart', '@account', '@hot']}, async ({page, browserName}) => {
     await test.step('Add another product to cart', async () =>{
       const productpage = new ProductPage(page);
-      await page.goto(slugs.productpage.secondSimpleProductSlug);
       await productpage.addSimpleProductToCart(UIReference.productPage.secondSimpleProducTitle, slugs.productpage.secondSimpleProductSlug);
     });
 
@@ -68,7 +68,8 @@ test.describe('Cart functionalities (guest)', () => {
       await loginPage.login(emailInputValue, passwordInputValue);
     });
 
-    await page.goto(slugs.cart.cartSlug);
+    const cartPage = new CartPage(page);
+    await cartPage.openCart();
     await expect(page.getByRole('strong').getByRole('link', { name: UIReference.productPage.simpleProductTitle }),`${UIReference.productPage.simpleProductTitle} should still be in cart`).toBeVisible();
     await expect(page.getByRole('strong').getByRole('link', { name: UIReference.productPage.secondSimpleProducTitle }),`${UIReference.productPage.secondSimpleProducTitle} should still be in cart`).toBeVisible();
   });
@@ -184,19 +185,19 @@ test.describe('Price checking tests', () => {
 
     await test.step('Step: Add simple product to cart', async () =>{
       const productPage = new ProductPage(page);
-      await page.goto(slugs.productpage.simpleProductSlug);
+      await productPage.openProductPage(slugs.productpage.simpleProductSlug);
       // set quantity to 2 so we can see that the math works
       await page.getByLabel(UIReference.productPage.quantityFieldLabel).fill('2');
 
       productPagePrice = await page.locator(UIReference.productPage.simpleProductPrice).innerText();
       productPageAmount = await page.getByLabel(UIReference.productPage.quantityFieldLabel).inputValue();
-      await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug, '2');
+      await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug, '2', false);
 
     });
 
     await test.step('Step: go to checkout, get values', async () =>{
-      await page.goto(slugs.checkout.checkoutSlug);
-      await page.waitForLoadState();
+      const checkoutPage = new CheckoutPage(page);
+      await checkoutPage.openCheckout();
 
       // returns productPriceInCheckout and productQuantityInCheckout
       checkoutProductDetails = await cart.getCheckoutValues(UIReference.productPage.simpleProductTitle, productPagePrice, productPageAmount);
@@ -226,20 +227,19 @@ test.describe('Price checking tests', () => {
 
     await test.step('Step: Add configurable product to cart', async () =>{
       const productPage = new ProductPage(page);
-      // Navigate to the configurable product page so we can retrieve price and amount before adding it to cart
-      await page.goto(slugs.productpage.configurableProductSlug);
+      await productPage.openProductPage(slugs.productpage.configurableProductSlug);
       // set quantity to 2 so we can see that the math works
       await page.getByLabel('Quantity').fill('2');
 
       productPagePrice = await page.locator(UIReference.productPage.simpleProductPrice).innerText();
       productPageAmount = await page.getByLabel(UIReference.productPage.quantityFieldLabel).inputValue();
-      await productPage.addConfigurableProductToCart(UIReference.productPage.configurableProductTitle, slugs.productpage.configurableProductSlug, '2');
+      await productPage.addConfigurableProductToCart(UIReference.productPage.configurableProductTitle, slugs.productpage.configurableProductSlug, '2', false);
 
     });
 
     await test.step('Step: go to checkout, get values', async () =>{
-      await page.goto(slugs.checkout.checkoutSlug);
-      await page.waitForLoadState();
+      const checkoutPage = new CheckoutPage(page);
+      await checkoutPage.openCheckout();
 
       // returns productPriceInCheckout and productQuantityInCheckout
       checkoutProductDetails = await cart.getCheckoutValues(UIReference.productPage.configurableProductTitle, productPagePrice, productPageAmount);

--- a/tests/checkout.spec.ts
+++ b/tests/checkout.spec.ts
@@ -24,9 +24,9 @@ import CheckoutPage from './poms/frontend/checkout.page';
 test.beforeEach(async ({ page }) => {
   const productPage = new ProductPage(page);
 
-  await page.goto(slugs.productpage.simpleProductSlug);
   await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
-  await page.goto(slugs.checkout.checkoutSlug);
+  const checkoutPageInit = new CheckoutPage(page);
+  await checkoutPageInit.openCheckout();
 });
 
 
@@ -39,7 +39,8 @@ test.describe('Checkout (login required)', () => {
 
     const loginPage = new LoginPage(page);
     await loginPage.login(emailInputValue, passwordInputValue);
-    await page.goto(slugs.checkout.checkoutSlug);
+    const checkoutPage = new CheckoutPage(page);
+    await checkoutPage.openCheckout();
   });
 
   /**
@@ -124,7 +125,8 @@ test.describe('Checkout (guest)', () => {
 
       // Add product to cart and go to checkout
       await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
-      await page.goto(slugs.checkout.checkoutSlug);
+      const checkoutPage = new CheckoutPage(page);
+      await checkoutPage.openCheckout();
 
       // Select shipping method to trigger price calculations
       await checkoutPage.shippingMethodOptionFixed.check();
@@ -191,7 +193,7 @@ test.describe('Checkout (guest)', () => {
 
     // Test with check/money order payment
     await test.step('Place order with check/money order payment', async () => {
-      await page.goto(slugs.checkout.checkoutSlug);
+      await checkoutPage.openCheckout();
       await checkoutPage.fillShippingAddress();
       await checkoutPage.shippingMethodOptionFixed.check();
       await checkoutPage.selectPaymentMethod('check');

--- a/tests/compare.spec.ts
+++ b/tests/compare.spec.ts
@@ -17,7 +17,8 @@ test.beforeEach('Add 2 products to compare, then navigate to comparison page', a
   });
 
   await test.step('Navigate to product comparison page', async () =>{
-    await page.goto(slugs.productpage.productComparisonSlug);
+    const comparePage = new ComparePage(page);
+    await comparePage.openComparisonPage();
     await expect(page.getByRole('heading', { name: UIReference.comparePage.comparisonPageTitleText }).locator('span')).toBeVisible();
   });
 });
@@ -72,8 +73,9 @@ test('Add_product_to_wishlist_from_comparison_page',{ tag: ['@comparison-page', 
   
   await test.step('Add product to compare', async () =>{
     const productPage = new ProductPage(page);
-    await page.goto(slugs.productpage.productComparisonSlug);
-    await productPage.addProductToCompare(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
+    const comparePage = new ComparePage(page);
+    await comparePage.openComparisonPage();
+    await productPage.addProductToCompare(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug, false);
   });
 
   await test.step('Add product to wishlist', async () =>{
@@ -87,11 +89,9 @@ test('Add_product_to_wishlist_from_comparison_page',{ tag: ['@comparison-page', 
 
 
 test.afterEach('Remove products from compare', async ({ page }) => {
-  // ensure we are on the right page
-  await page.goto(slugs.productpage.productComparisonSlug);
-
-  page.on('dialog', dialog => dialog.accept());
   const comparePage = new ComparePage(page);
+  await comparePage.openComparisonPage();
+  page.on('dialog', dialog => dialog.accept());
   await comparePage.removeProductFromCompare(UIReference.productPage.simpleProductTitle);
   await comparePage.removeProductFromCompare(UIReference.productPage.secondSimpleProducTitle);
 });

--- a/tests/config/slugs.json
+++ b/tests/config/slugs.json
@@ -35,4 +35,7 @@
   "wishlist": {
     "wishListRegex": ".*wishlist.*"
   }
+  ,"home": {
+    "homeSlug": "/"
+  }
 }

--- a/tests/healthcheck.spec.ts
+++ b/tests/healthcheck.spec.ts
@@ -2,6 +2,10 @@
 
 import { test, expect } from '@playwright/test';
 import { UIReference, slugs } from 'config';
+import HomePage from './poms/frontend/home.page';
+import CategoryPage from './poms/frontend/category.page';
+import ProductPage from './poms/frontend/product.page';
+import CheckoutPage from './poms/frontend/checkout.page';
 
 test.describe('Page health checks', () => {
     test('Homepage_returns_200', { tag: ['@smoke', '@cold'] }, async ({page}) => {
@@ -11,7 +15,8 @@ test.describe('Page health checks', () => {
         }
 
         const homepageResponsePromise = page.waitForResponse(homepageURL);
-        await page.goto(homepageURL);
+        const homePage = new HomePage(page);
+        await homePage.openHomePage();
         const homepageResponse = await homepageResponsePromise;
         expect(homepageResponse.status(), 'Homepage should return 200').toBe(200);
 
@@ -23,7 +28,8 @@ test.describe('Page health checks', () => {
 
     test('Plp_returns_200', { tag: ['@smoke', '@cold'] }, async ({page}) => {
         const plpResponsePromise = page.waitForResponse(slugs.categoryPage.categorySlug);
-        await page.goto(slugs.categoryPage.categorySlug);
+        const categoryPage = new CategoryPage(page);
+        await categoryPage.goToCategoryPage();
         const plpResponse = await plpResponsePromise;
         expect(plpResponse.status(), 'PLP should return 200').toBe(200);
 
@@ -35,7 +41,8 @@ test.describe('Page health checks', () => {
 
     test('Pdp_returns_200', { tag: ['@smoke', '@cold'] }, async ({page}) => {
         const pdpResponsePromise = page.waitForResponse(slugs.productpage.simpleProductSlug);
-        await page.goto(slugs.productpage.simpleProductSlug);
+        const productPage = new ProductPage(page);
+        await productPage.openProductPage(slugs.productpage.simpleProductSlug);
         const pdpResponse = await pdpResponsePromise;
         expect(pdpResponse.status(), 'PDP should return 200').toBe(200);
 
@@ -48,7 +55,8 @@ test.describe('Page health checks', () => {
     test('Checkout_returns_200', { tag: ['@smoke', '@cold'] }, async ({page}) => {
         const responsePromise = page.waitForResponse(slugs.checkout.checkoutSlug);
 
-        await page.goto(slugs.checkout.checkoutSlug);
+        const checkoutPage = new CheckoutPage(page);
+        await checkoutPage.openCheckout();
         const response = await responsePromise;
 
         expect(response.status(), 'Cart empty, checkout should return 302').toBe(302);

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -10,7 +10,7 @@ test('Add_product_on_homepage_to_cart',{ tag: ['@homepage', '@cold']}, async ({p
   const homepage = new HomePage(page);
   const mainmenu = new MainMenuPage(page);
 
-  await page.goto('');
+  await homepage.openHomePage();
   await homepage.addHomepageProductToCart();
   await mainmenu.openMiniCart();
   await expect(page.getByText('x ' + outcomeMarker.homePage.firstProductName), 'product should be visible in cart').toBeVisible();

--- a/tests/minicart.spec.ts
+++ b/tests/minicart.spec.ts
@@ -24,7 +24,6 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
     const mainMenu = new MainMenuPage(page);
     const productPage = new ProductPage(page);
 
-    await page.goto(slugs.productpage.simpleProductSlug);
     await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
     await mainMenu.openMiniCart();
     await expect(page.getByText(outcomeMarker.miniCart.simpleProductInCartTitle)).toBeVisible();
@@ -114,7 +113,6 @@ test.describe('Minicart Actions', {annotation: {type: 'Minicart', description: '
     const mainMenu = new MainMenuPage(page);
     const productPage = new ProductPage(page);
 
-    await page.goto(slugs.productpage.configurableProductSlug);
     await productPage.addConfigurableProductToCart(UIReference.productPage.configurableProductTitle, slugs.productpage.configurableProductSlug, '2');
     await mainMenu.openMiniCart();
     await expect(page.getByText(outcomeMarker.miniCart.configurableProductMinicartTitle)).toBeVisible();

--- a/tests/orderhistory.spec.ts
+++ b/tests/orderhistory.spec.ts
@@ -21,9 +21,7 @@ test('Recent_order_is_visible_in_history', async ({ page, browserName }) => {
 
   await loginPage.login(emailInputValue, passwordInputValue);
 
-  await page.goto(slugs.productpage.simpleProductSlug);
   await productPage.addSimpleProductToCart(UIReference.productPage.simpleProductTitle, slugs.productpage.simpleProductSlug);
-  await page.goto(slugs.checkout.checkoutSlug);
   const orderNumberLocator = await checkoutPage.placeOrder();
   const orderNumberText = await orderNumberLocator.innerText();
   const orderNumber = orderNumberText.replace(/\D/g, '');

--- a/tests/poms/frontend/account.page.ts
+++ b/tests/poms/frontend/account.page.ts
@@ -2,7 +2,7 @@
 
 import { expect, type Locator, type Page } from '@playwright/test';
 import { faker } from '@faker-js/faker';
-import { UIReference, outcomeMarker, inputValues } from 'config';
+import { UIReference, outcomeMarker, inputValues, slugs } from 'config';
 import LoginPage from './login.page';
 
 class AccountPage {
@@ -77,6 +77,31 @@ class AccountPage {
     this.addNewAddressButton = page.getByRole('button', { name: UIReference.accountDashboard.addAddressButtonLabel });
     this.deleteAddressButton = page.getByRole('link', { name: UIReference.accountDashboard.addressDeleteIconButton }).first();
     this.editAddressButton = page.getByRole('link', { name: UIReference.accountDashboard.editAddressIconButton }).first();
+  }
+
+  async openAccountOverview() {
+    await this.page.goto(slugs.account.accountOverviewSlug);
+    await this.page.waitForLoadState();
+  }
+
+  async openChangePassword() {
+    await this.page.goto(slugs.account.changePasswordSlug);
+    await this.page.waitForLoadState();
+  }
+
+  async openAccountEdit() {
+    await this.page.goto(slugs.account.accountEditSlug);
+    await this.page.waitForLoadState();
+  }
+
+  async openAddressNew() {
+    await this.page.goto(slugs.account.addressNewSlug);
+    await this.page.waitForLoadState();
+  }
+
+  async openAddressBook() {
+    await this.page.goto(slugs.account.addressBookSlug);
+    await this.page.waitForLoadState();
   }
 
   async addNewAddress(values?: {

--- a/tests/poms/frontend/cart.page.ts
+++ b/tests/poms/frontend/cart.page.ts
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { expect, type Locator, type Page } from '@playwright/test';
-import { UIReference, outcomeMarker } from 'config';
+import { UIReference, outcomeMarker, slugs } from 'config';
 
 class CartPage {
   readonly page: Page;
@@ -12,6 +12,11 @@ class CartPage {
   constructor(page: Page) {
     this.page = page;
     this.showDiscountButton = this.page.getByRole('button', { name: UIReference.cart.showDiscountFormButtonLabel });
+  }
+
+  async openCart() {
+    await this.page.goto(slugs.cart.cartSlug);
+    await this.page.waitForLoadState();
   }
 
   async changeProductQuantity(amount: string){

--- a/tests/poms/frontend/checkout.page.ts
+++ b/tests/poms/frontend/checkout.page.ts
@@ -43,6 +43,11 @@ class CheckoutPage extends MagewireUtils {
     this.creditCardNameField = this.page.getByLabel(UIReference.checkout.creditCardNameLabel);
   }
 
+  async openCheckout() {
+    await this.page.goto(slugs.checkout.checkoutSlug);
+    await this.page.waitForLoadState();
+  }
+
   // ==============================================
   // Order-related methods
   // ==============================================

--- a/tests/poms/frontend/compare.page.ts
+++ b/tests/poms/frontend/compare.page.ts
@@ -1,13 +1,18 @@
 // @ts-check
 
 import { expect, type Page } from '@playwright/test';
-import { UIReference, outcomeMarker } from 'config';
+import { UIReference, outcomeMarker, slugs } from 'config';
 
 class ComparePage {
   page: Page;
 
   constructor(page: Page) {
     this.page = page;
+  }
+
+  async openComparisonPage() {
+    await this.page.goto(slugs.productpage.productComparisonSlug);
+    await this.page.waitForLoadState();
   }
 
   async removeProductFromCompare(product:string){

--- a/tests/poms/frontend/contact.page.ts
+++ b/tests/poms/frontend/contact.page.ts
@@ -19,8 +19,10 @@ class ContactPage {
     this.sendFormButton = this.page.getByRole('button', { name: UIReference.general.genericSubmitButtonLabel });
   }
 
-  async fillOutForm(){
-    await this.page.goto(slugs.contact.contactSlug);
+  async fillOutForm(navigate: boolean = true){
+    if(navigate){
+      await this.page.goto(slugs.contact.contactSlug);
+    }
     let messageSentConfirmationText = outcomeMarker.contactPage.messageSentConfirmationText;
 
     // Add a wait for the form to be visible

--- a/tests/poms/frontend/home.page.ts
+++ b/tests/poms/frontend/home.page.ts
@@ -1,7 +1,7 @@
 // @ts-check
 
 import { type Page } from '@playwright/test';
-import { UIReference } from 'config';
+import { UIReference, slugs } from 'config';
 
 class HomePage {
 
@@ -9,6 +9,10 @@ class HomePage {
 
   constructor(page: Page) {
     this.page = page;
+  }
+
+  async openHomePage() {
+    await this.page.goto(slugs.home.homeSlug);
   }
 
   async addHomepageProductToCart(){

--- a/tests/poms/frontend/product.page.ts
+++ b/tests/poms/frontend/product.page.ts
@@ -18,15 +18,22 @@ class ProductPage {
     this.addToWishlistButton = page.getByLabel(UIReference.productPage.addToWishlistButtonLabel, { exact: true });
   }
 
+  async openProductPage(url: string) {
+    await this.page.goto(url);
+    await this.page.waitForLoadState();
+  }
+
   // ==============================================
   // Productpage-related methods
   // ==============================================
 
-  async addProductToCompare(product:string, url: string){
+  async addProductToCompare(product:string, url: string, navigate: boolean = true){
     let productAddedNotification = `${outcomeMarker.productPage.simpleProductAddedNotification} product`;
     const successMessage = this.page.locator(UIReference.general.successMessageLocator);
 
-    await this.page.goto(url);
+    if(navigate){
+      await this.page.goto(url);
+    }
     await this.addToCompareButton.click();
     await successMessage.waitFor();
     await expect(this.page.getByText(productAddedNotification)).toBeVisible();
@@ -37,9 +44,11 @@ class ProductPage {
     await expect(this.page.getByRole('cell', {name: product}).getByText(product, {exact: true})).toBeVisible();
   }
 
-  async addProductToWishlist(product:string, url: string){
+  async addProductToWishlist(product:string, url: string, navigate: boolean = true){
     let addedToWishlistNotification = `${product} ${outcomeMarker.wishListPage.wishListAddedNotification}`;
-    await this.page.goto(url);
+    if(navigate){
+      await this.page.goto(url);
+    }
     await this.addToWishlistButton.click();
 
     await this.page.waitForLoadState();
@@ -51,8 +60,10 @@ class ProductPage {
     await expect(productNameInWishlist).toContainText(product);
   }
 
-  async leaveProductReview(product:string, url: string){
-    await this.page.goto(url);
+  async leaveProductReview(product:string, url: string, navigate: boolean = true){
+    if(navigate){
+      await this.page.goto(url);
+    }
 
     //TODO: Uncomment this and fix test once website is fixed
     /*
@@ -69,8 +80,10 @@ class ProductPage {
     */
   }
 
-  async openLightboxAndScrollThrough(url: string){
-    await this.page.goto(url);
+  async openLightboxAndScrollThrough(url: string, navigate: boolean = true){
+    if(navigate){
+      await this.page.goto(url);
+    }
     let fullScreenOpener = this.page.getByLabel(UIReference.productPage.fullScreenOpenLabel);
     let fullScreenCloser = this.page.getByLabel(UIReference.productPage.fullScreenCloseLabel);
     let thumbnails = this.page.getByRole('button', {name: UIReference.productPage.thumbnailImageLabel});
@@ -90,8 +103,10 @@ class ProductPage {
 
   }
 
-  async changeReviewCountAndVerify(url: string) {
-    await this.page.goto(url);
+  async changeReviewCountAndVerify(url: string, navigate: boolean = true) {
+    if(navigate){
+      await this.page.goto(url);
+    }
 
     // Get the default review count from URL or UI
     const initialUrl = this.page.url();
@@ -123,9 +138,11 @@ class ProductPage {
   // Cart-related methods
   // ==============================================
 
-  async addSimpleProductToCart(product: string, url: string, quantity?: string) {
+  async addSimpleProductToCart(product: string, url: string, quantity?: string, navigate: boolean = true) {
 
-    await this.page.goto(url);
+    if(navigate){
+      await this.page.goto(url);
+    }
     this.simpleProductTitle = this.page.getByRole('heading', {name: product, exact:true});
     expect(await this.simpleProductTitle.innerText()).toEqual(product);
     await expect(this.simpleProductTitle.locator('span')).toBeVisible();
@@ -141,8 +158,10 @@ class ProductPage {
     return ;
   }
 
-  async addConfigurableProductToCart(product: string, url:string, quantity?:string){
-    await this.page.goto(url);
+  async addConfigurableProductToCart(product: string, url:string, quantity?:string, navigate: boolean = true){
+    if(navigate){
+      await this.page.goto(url);
+    }
     this.configurableProductTitle = this.page.getByRole('heading', {name: product, exact:true});
     let productAddedNotification = `${outcomeMarker.productPage.simpleProductAddedNotification} ${product}`;
     const productOptions = this.page.locator(UIReference.productPage.configurableProductOptionForm);

--- a/tests/poms/frontend/register.page.ts
+++ b/tests/poms/frontend/register.page.ts
@@ -23,9 +23,11 @@ class RegisterPage {
   }
 
 
-  async createNewAccount(firstName: string, lastName: string, email: string, password: string, muted: boolean = false){
+  async createNewAccount(firstName: string, lastName: string, email: string, password: string, muted: boolean = false, navigate: boolean = true){
     let accountInformationField = this.page.locator(UIReference.accountDashboard.accountInformationFieldLocator).first();
-    await this.page.goto(slugs.account.createAccountSlug);
+    if(navigate){
+      await this.page.goto(slugs.account.createAccountSlug);
+    }
 
     await this.accountCreationFirstNameField.fill(firstName);
     await this.accountCreationLastNameField.fill(lastName);

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -4,10 +4,12 @@ import { test, expect } from '@playwright/test';
 import { UIReference, outcomeMarker, inputValues, slugs } from 'config';
 
 import SearchPage from './poms/frontend/search.page';
+import HomePage from './poms/frontend/home.page';
 
 test.describe('Search functionality', () => {
   test('Search_query_returns_multiple_results', async ({ page }) => {
-    await page.goto('');
+    const homePage = new HomePage(page);
+    await homePage.openHomePage();
     const searchPage = new SearchPage(page);
     await searchPage.search(inputValues.search.queryMultipleResults);
     await expect(page).toHaveURL(new RegExp(slugs.search.resultsSlug));
@@ -17,14 +19,16 @@ test.describe('Search functionality', () => {
   });
 
   test('User_can_find_a_specific_product_and_navigate_to_its_page', async ({ page }) => {
-    await page.goto('');
+    const homePage2 = new HomePage(page);
+    await homePage2.openHomePage();
     const searchPage = new SearchPage(page);
     await searchPage.search(inputValues.search.querySpecificProduct);
     await expect(page).toHaveURL(slugs.productpage.simpleProductSlug);
   });
 
   test('No_results_message_is_shown_for_unknown_query', async ({ page }) => {
-    await page.goto('');
+    const homePage3 = new HomePage(page);
+    await homePage3.openHomePage();
     const searchPage = new SearchPage(page);
     await searchPage.search(inputValues.search.queryNoResults);
     await expect(page.getByText(outcomeMarker.search.noResultsMessage)).toBeVisible();


### PR DESCRIPTION
## Summary
- add home slug
- expose `openHomePage` and other page navigation helpers
- support optional navigation parameters in page objects
- switch tests and setup to use page object navigation

## Testing
- `npx playwright test --list` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_686bcb8d61cc832b8bfd76f4df991051